### PR TITLE
PES-3150: add consign password functionality for Z-BOX

### DIFF
--- a/CHANGE_LOG.txt
+++ b/CHANGE_LOG.txt
@@ -8,6 +8,7 @@
       - Added: print shipping label from order list
       - Added: mass print shipping labels from order list
       - Added: ability to cancel submitted packet from order list
+      - Added: option to display Z-BOX consign password in Packeta order detail and order list
 
 2.4.0 - Updated: checking and correcting address in checkout is possible only for home delivery to Czech Republic and Slovakia
       - Updated: in Packeta order detail you can change pickup point or delivery address only when the order allows it; otherwise you see a notice that no changes are possible

--- a/Packetery/Checkout/Model/Api/Request/PacketInfoRequest.php
+++ b/Packetery/Checkout/Model/Api/Request/PacketInfoRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Packetery\Checkout\Model\Api\Request;
+
+class PacketInfoRequest
+{
+    private string $apiPassword;
+
+    private string $packetId;
+
+    public function __construct(string $apiPassword, string $packetId)
+    {
+        $this->apiPassword = $apiPassword;
+        $this->packetId = $packetId;
+    }
+
+    public function getApiPassword(): string
+    {
+        return $this->apiPassword;
+    }
+
+    public function getPacketId(): string
+    {
+        return $this->packetId;
+    }
+}

--- a/Packetery/Checkout/Model/Api/Result/PacketInfoResult.php
+++ b/Packetery/Checkout/Model/Api/Result/PacketInfoResult.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Packetery\Checkout\Model\Api\Result;
+
+class PacketInfoResult
+{
+    private ?string $consignPassword = null;
+
+    private string $fault = '';
+
+    private string $faultString = '';
+
+    public function getConsignPassword(): ?string
+    {
+        return $this->consignPassword;
+    }
+
+    public function setConsignPassword(?string $consignPassword): void
+    {
+        $this->consignPassword = $consignPassword;
+    }
+
+    public function getFault(): string
+    {
+        return $this->fault;
+    }
+
+    public function setFault(string $fault): void
+    {
+        $this->fault = $fault;
+    }
+
+    public function getFaultString(): string
+    {
+        return $this->faultString;
+    }
+
+    public function setFaultString(string $faultString): void
+    {
+        $this->faultString = $faultString;
+    }
+}

--- a/Packetery/Checkout/Model/Api/SoapApiClient.php
+++ b/Packetery/Checkout/Model/Api/SoapApiClient.php
@@ -138,6 +138,27 @@ class SoapApiClient
         return $response;
     }
 
+    public function packetInfo(
+        \Packetery\Checkout\Model\Api\Request\PacketInfoRequest $request
+    ): \Packetery\Checkout\Model\Api\Result\PacketInfoResult {
+        $apiPassword = $request->getApiPassword();
+        $packetId = $request->getPacketId();
+
+        $response = new \Packetery\Checkout\Model\Api\Result\PacketInfoResult();
+        try {
+            $client = $this->createSoapClient();
+            $info = $client->packetInfo($apiPassword, $packetId);
+            if (isset($info->consignPassword) && $info->consignPassword !== '') {
+                $response->setConsignPassword((string) $info->consignPassword);
+            }
+        } catch (\SoapFault $e) {
+            $response->setFault($this->getFaultIdentifier($e));
+            $response->setFaultString($e->getMessage());
+        }
+
+        return $response;
+    }
+
     /**
      * @throws \SoapFault
      */

--- a/Packetery/Checkout/Model/Carrier/Cache.php
+++ b/Packetery/Checkout/Model/Carrier/Cache.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Packetery\Checkout\Model\Carrier;
+
+class Cache
+{
+    /** @var array<int, array<string, \Magento\Shipping\Model\Carrier\AbstractCarrier|null>> */
+    private array $data = [];
+
+    public function has(int $storeId, string $carrierCode): bool
+    {
+        return isset($this->data[$storeId]) && array_key_exists($carrierCode, $this->data[$storeId]);
+    }
+
+    public function get(int $storeId, string $carrierCode): ?\Magento\Shipping\Model\Carrier\AbstractCarrier
+    {
+        return $this->data[$storeId][$carrierCode] ?? null;
+    }
+
+    public function set(int $storeId, string $carrierCode, ?\Magento\Shipping\Model\Carrier\AbstractCarrier $value): void
+    {
+        $this->data[$storeId][$carrierCode] = $value;
+    }
+}

--- a/Packetery/Checkout/Model/Carrier/CarrierFactory.php
+++ b/Packetery/Checkout/Model/Carrier/CarrierFactory.php
@@ -16,22 +16,15 @@ class CarrierFactory
     }
 
     public function createCached(
-        array &$cache,
+        Cache $cache,
         string $carrierCode,
         int $storeId
-    ): ?\Magento\Shipping\Model\Carrier\AbstractCarrier
-    {
-        $cache['carriers'] = $cache['carriers'] ?? [];
-        $cache['carriers'][$storeId] = $cache['carriers'][$storeId] ?? [];
-
-        if (!array_key_exists($carrierCode, $cache['carriers'][$storeId])) {
-            $carrier = $this->carrierFactory->create($carrierCode, $storeId);
-            $cache['carriers'][$storeId][$carrierCode] = ($carrier instanceof \Magento\Shipping\Model\Carrier\AbstractCarrier)
-                ? $carrier
-                : null;
+    ): ?\Magento\Shipping\Model\Carrier\AbstractCarrier {
+        if (!$cache->has($storeId, $carrierCode)) {
+            $cache->set($storeId, $carrierCode, $this->create($carrierCode, $storeId));
         }
 
-        return $cache['carriers'][$storeId][$carrierCode];
+        return $cache->get($storeId, $carrierCode);
     }
 
     public function create(string $carrierCode, int $storeId): ?\Magento\Shipping\Model\Carrier\AbstractCarrier
@@ -41,4 +34,3 @@ class CarrierFactory
         return ($carrier instanceof \Magento\Shipping\Model\Carrier\AbstractCarrier) ? $carrier : null;
     }
 }
-

--- a/Packetery/Checkout/Model/Carrier/Facade.php
+++ b/Packetery/Checkout/Model/Carrier/Facade.php
@@ -175,6 +175,18 @@ class Facade
         return $this->carrierFactory->get($carrierCode);
     }
 
+    public function getPacketeryCarrierConfig(int $storeId): ?\Packetery\Checkout\Model\Carrier\Imp\Packetery\Config {
+        $carrier = $this->carrierFactory->create(\Packetery\Checkout\Model\Carrier\Imp\Packetery\Brain::getCarrierCodeStatic(), $storeId);
+        if ($carrier instanceof \Packetery\Checkout\Model\Carrier\Imp\Packetery\Carrier) {
+            $config = $carrier->getPacketeryConfig();
+            if ($config instanceof \Packetery\Checkout\Model\Carrier\Imp\Packetery\Config) {
+                return $config;
+            }
+        }
+
+        return null;
+    }
+
     /**
      * @return array<class-string<\Packetery\Checkout\Model\Carrier\AbstractBrain>>
      */

--- a/Packetery/Checkout/Model/Carrier/Imp/Packetery/Config.php
+++ b/Packetery/Checkout/Model/Carrier/Imp/Packetery/Config.php
@@ -52,6 +52,11 @@ class Config extends \Packetery\Checkout\Model\Carrier\Config\AbstractConfig
         return ($this->getConfigData('sender') ?: null);
     }
 
+    public function isShowConsignPassword(): bool
+    {
+        return $this->getConfigData('show_consign_password') === '1';
+    }
+
     protected function normalizeLabelFormatValue(string $value): string
     {
         return LabelFormats::normalizePacketaFormat($value);

--- a/Packetery/Checkout/Model/Packet.php
+++ b/Packetery/Checkout/Model/Packet.php
@@ -117,4 +117,20 @@ class Packet extends \Magento\Framework\Model\AbstractModel
         $this->setData('label_printed_at', $utc->format('Y-m-d H:i:s'));
         return $this;
     }
+
+    public function getConsignPassword(): ?string
+    {
+        $value = $this->getData('consign_password');
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return (string) $value;
+    }
+
+    public function setConsignPassword(?string $consignPassword): self
+    {
+        $this->setData('consign_password', ($consignPassword === '' ? null : $consignPassword));
+        return $this;
+    }
 }

--- a/Packetery/Checkout/Model/Packet/PacketSubmitter.php
+++ b/Packetery/Checkout/Model/Packet/PacketSubmitter.php
@@ -30,6 +30,9 @@ class PacketSubmitter
     /** @var \Packetery\Checkout\Model\ResourceModel\Order */
     private $orderResource;
 
+    /** @var \Packetery\Checkout\Model\Carrier\Facade */
+    private $carrierFacade;
+
     public function __construct(
         \Packetery\Checkout\Model\Api\SoapApiClient $soapApiClient,
         \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
@@ -37,7 +40,8 @@ class PacketSubmitter
         \Packetery\Checkout\Model\PacketFactory $packetFactory,
         \Packetery\Checkout\Model\ResourceModel\Packet\CollectionFactory $packetCollectionFactory,
         \Packetery\Checkout\Model\ResourceModel\Packet $packetResource,
-        \Packetery\Checkout\Model\ResourceModel\Order $orderResource
+        \Packetery\Checkout\Model\ResourceModel\Order $orderResource,
+        \Packetery\Checkout\Model\Carrier\Facade $carrierFacade
     ) {
         $this->soapApiClient = $soapApiClient;
         $this->scopeConfig = $scopeConfig;
@@ -46,6 +50,7 @@ class PacketSubmitter
         $this->packetCollectionFactory = $packetCollectionFactory;
         $this->packetResource = $packetResource;
         $this->orderResource = $orderResource;
+        $this->carrierFacade = $carrierFacade;
     }
 
     /**
@@ -122,7 +127,15 @@ class PacketSubmitter
         }
 
         $createResult = $this->soapApiClient->createPacket($apiPassword, $attributes);
-        $this->savePacket($packeteryOrder->getOrderNumber(), $createResult->getPacketId(), $weight, $value, $cod);
+
+        $consignPassword = null;
+        $packeteryConfig = $this->carrierFacade->getPacketeryCarrierConfig($storeId);
+        if ($packeteryConfig !== null && $packeteryConfig->isShowConsignPassword()) {
+            $request = new \Packetery\Checkout\Model\Api\Request\PacketInfoRequest($apiPassword, $createResult->getPacketId());
+            $consignPassword = $this->soapApiClient->packetInfo($request)->getConsignPassword();
+        }
+
+        $this->savePacket($packeteryOrder->getOrderNumber(), $createResult->getPacketId(), $weight, $value, $cod, $consignPassword);
         $this->markOrderExported($packeteryOrder);
     }
 
@@ -142,7 +155,7 @@ class PacketSubmitter
         return $this->weightCalculator->getOrderWeight($magentoOrder);
     }
 
-    private function savePacket(string $orderNumber, string $packetId, float $weight, float $value, float $cod): void
+    private function savePacket(string $orderNumber, string $packetId, float $weight, float $value, float $cod, ?string $consignPassword): void
     {
         $packet = $this->packetFactory->create();
         $packet->setOrderNumber($orderNumber);
@@ -150,6 +163,7 @@ class PacketSubmitter
         $packet->setWeight($weight);
         $packet->setValue($value);
         $packet->setCod($cod);
+        $packet->setConsignPassword($consignPassword);
         $this->packetResource->save($packet);
     }
 

--- a/Packetery/Checkout/Setup/InstallSchema.php
+++ b/Packetery/Checkout/Setup/InstallSchema.php
@@ -556,6 +556,11 @@ class InstallSchema implements InstallSchemaInterface
                 'type' => Table::TYPE_DATETIME,
                 'attr' => ['nullable' => true, 'comment' => 'UTC date and time of last successful label print'],
             ],
+            'consign_password' => [
+                'type' => Table::TYPE_TEXT,
+                'size' => 10,
+                'attr' => ['nullable' => true, 'comment' => 'Z-BOX consign password returned by Packeta API'],
+            ],
         ]);
 
         $table->addIndex(

--- a/Packetery/Checkout/Ui/Component/Order/Listing/Column/Actions.php
+++ b/Packetery/Checkout/Ui/Component/Order/Listing/Column/Actions.php
@@ -64,7 +64,7 @@ class Actions extends Column
     public function prepareDataSource(array $dataSource): array
     {
         if (isset($dataSource['data']['items'])) {
-            $carrierCache = [];
+            $cache = new \Packetery\Checkout\Model\Carrier\Cache();
             foreach ($dataSource['data']['items'] as &$item) {
                 $name = $this->getData('name');
 
@@ -129,7 +129,11 @@ class Actions extends Column
                 $carrierCode = $shippingRateCode->getCarrierCode();
 
                 $storeId = (int) $order->getStoreId();
-                $carrier = $this->carrierFactory->createCached($carrierCache, $carrierCode, $storeId);
+                $carrier = $this->carrierFactory->createCached(
+                    $cache,
+                    $carrierCode,
+                    $storeId
+                );
                 if (!$carrier instanceof \Magento\Shipping\Model\Carrier\AbstractCarrier) {
                     continue;
                 }

--- a/Packetery/Checkout/Ui/Component/Order/Listing/Column/ConsignPassword.php
+++ b/Packetery/Checkout/Ui/Component/Order/Listing/Column/ConsignPassword.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Packetery\Checkout\Ui\Component\Order\Listing\Column;
+
+class ConsignPassword extends \Magento\Ui\Component\Listing\Columns\Column
+{
+    /** @var \Packetery\Checkout\Model\Carrier\Facade */
+    private $carrierFacade;
+
+    public function __construct(
+        \Magento\Framework\View\Element\UiComponent\ContextInterface $context,
+        \Magento\Framework\View\Element\UiComponentFactory $uiComponentFactory,
+        \Packetery\Checkout\Model\Carrier\Facade $carrierFacade,
+        array $components = [],
+        array $data = []
+    ) {
+        $this->carrierFacade = $carrierFacade;
+        parent::__construct($context, $uiComponentFactory, $components, $data);
+    }
+
+    public function prepareDataSource(array $dataSource): array
+    {
+        if (!isset($dataSource['data']['items'])) {
+            return $dataSource;
+        }
+
+        $name = $this->getData('name');
+
+        foreach ($dataSource['data']['items'] as &$item) {
+            $storeId = isset($item['store_id']) ? (int) $item['store_id'] : 0;
+            $config = $this->carrierFacade->getPacketeryCarrierConfig($storeId);
+            if ($config === null || !$config->isShowConsignPassword()) {
+                $item[$name] = '';
+            }
+        }
+
+        return $dataSource;
+    }
+}

--- a/Packetery/Checkout/Ui/Component/Order/Listing/SearchResult.php
+++ b/Packetery/Checkout/Ui/Component/Order/Listing/SearchResult.php
@@ -59,8 +59,13 @@ class SearchResult extends \Magento\Framework\View\Element\UiComponent\DataProvi
         $subQuery = $orderCollection->getSelect();
         $packetTable = $orderCollection->getTable('packetery_packet');
         $connection = $orderCollection->getConnection();
-        $packetSubSelect = $connection->select()
+        $packetNumberSubSelect = $connection->select()
             ->from(['p' => $packetTable], ['packet_number'])
+            ->where('p.order_number = main_table.order_number')
+            ->order('p.id DESC')
+            ->limit(1);
+        $consignPasswordSubSelect = $connection->select()
+            ->from(['p' => $packetTable], ['consign_password'])
             ->where('p.order_number = main_table.order_number')
             ->order('p.id DESC')
             ->limit(1);
@@ -75,9 +80,11 @@ class SearchResult extends \Magento\Framework\View\Element\UiComponent\DataProvi
                 'cod_transformed' => "IF(main_table.cod > 0, 1, 0)",
                 'exported_transformed' => "main_table.exported",
                 'exported_at_transformed' => "main_table.exported_at",
-                'packet_number' => new Expression('(' . $packetSubSelect->assemble() . ')'),
+                'packet_number' => new Expression('(' . $packetNumberSubSelect->assemble() . ')'),
+                'consign_password' => new Expression('(' . $consignPasswordSubSelect->assemble() . ')'),
                 'order_status' => "sales_order.status",
                 'shipping_rate_code' => "sales_order.shipping_method",
+                'store_id' => 'sales_order.store_id',
                 'created_at' => 'sales_order.created_at',
                 'main_table.*'
             ]

--- a/Packetery/Checkout/Ui/Order/DataProvider.php
+++ b/Packetery/Checkout/Ui/Order/DataProvider.php
@@ -21,6 +21,9 @@ class DataProvider extends AbstractDataProvider
     /** @var \Packetery\Checkout\Model\Carrier\Facade */
     private $carrierFacade;
 
+    /** @var \Packetery\Checkout\Model\PacketRepository */
+    private $packetRepository;
+
     /**
      * @param string $name
      * @param string $primaryFieldName
@@ -28,6 +31,7 @@ class DataProvider extends AbstractDataProvider
      * @param \Packetery\Checkout\Model\ResourceModel\Order\CollectionFactory $collectionFactory
      * @param \Magento\Sales\Model\OrderFactory $orderFactory
      * @param \Packetery\Checkout\Model\Carrier\Facade $carrierFacade
+     * @param \Packetery\Checkout\Model\PacketRepository $packetRepository
      * @param array $meta
      * @param array $data
      */
@@ -38,6 +42,7 @@ class DataProvider extends AbstractDataProvider
         \Packetery\Checkout\Model\ResourceModel\Order\CollectionFactory $collectionFactory,
         \Magento\Sales\Model\OrderFactory $orderFactory,
         \Packetery\Checkout\Model\Carrier\Facade $carrierFacade,
+        \Packetery\Checkout\Model\PacketRepository $packetRepository,
         array $meta = [],
         array $data = []
     ) {
@@ -45,6 +50,7 @@ class DataProvider extends AbstractDataProvider
         $this->collection = $collectionFactory->create();
         $this->orderFactory = $orderFactory;
         $this->carrierFacade = $carrierFacade;
+        $this->packetRepository = $packetRepository;
     }
 
     /**
@@ -57,7 +63,15 @@ class DataProvider extends AbstractDataProvider
         foreach ($this->collection->getItems() as $item) {
             $result[$item->getId()]['general'] = $item->getData(); // princing rules
             $orderNumber = $result[$item->getId()]['general']['order_number'];
+            $packet = $this->packetRepository->findLatestByOrderNumber($orderNumber);
+            $consignPassword = $packet === null ? null : $packet->getConsignPassword();
+            $result[$item->getId()]['general']['consign_password'] = $consignPassword;
             $order = $this->orderFactory->create()->loadByIncrementId($orderNumber);
+
+            $packeteryConfig = $this->carrierFacade->getPacketeryCarrierConfig((int) $order->getStoreId());
+            $isShowConsignPassword = $packeteryConfig !== null && $packeteryConfig->isShowConsignPassword();
+            $showConsignPassword = $isShowConsignPassword && $consignPassword !== null;
+            $result[$item->getId()]['general']['misc']['showConsignPassword'] = $showConsignPassword ? '1' : '0';
 
             $shippingMethod = $order->getShippingMethod();
             if ($shippingMethod && ShippingRateCode::isPacketery($shippingMethod) && $order->getShippingAddress()) {

--- a/Packetery/Checkout/etc/adminhtml/system.xml
+++ b/Packetery/Checkout/etc/adminhtml/system.xml
@@ -65,6 +65,10 @@
                     <source_model>Packetery\Checkout\Model\Config\Source\PaymentMethod</source_model>
                     <comment>The payment methods selected above will be considered as cash on delivery (for Packeta).</comment>
                 </field>
+                <field id="show_consign_password" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="80" translate="label" type="select">
+                    <label>Show consign password for Z-BOX</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
                 <field id="sort_order" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="9000" translate="label" type="text">
                     <label>Sort Order</label>
                 </field>

--- a/Packetery/Checkout/etc/config.xml
+++ b/Packetery/Checkout/etc/config.xml
@@ -14,6 +14,7 @@
 				<label_format>A6 on A4</label_format>
 				<specificerrmsg>This shipping method is not available. To use this shipping method, please contact us.</specificerrmsg>
 				<sallowspecific>0</sallowspecific>
+				<show_consign_password>0</show_consign_password>
 			</packetery>
 			<packeteryPacketaDynamic>
 				<model>Packetery\Checkout\Model\Carrier\Imp\PacketeryPacketaDynamic\Carrier</model>

--- a/Packetery/Checkout/i18n/cs_CZ.csv
+++ b/Packetery/Checkout/i18n/cs_CZ.csv
@@ -204,3 +204,6 @@
 "Labels could not be generated. %1","Štítky se nepodařilo vygenerovat. %1"
 "If you are not redirected automatically,","Pokud nedojde k automatickému přesměrování,"
 "click here","klikněte zde"
+"Show consign password for Z-BOX","Zobrazit heslo pro podání do Z-BOXu"
+"Consign password","Heslo pro podání"
+"Show consign password","Zobrazit heslo pro podání"

--- a/Packetery/Checkout/i18n/en_GB.csv
+++ b/Packetery/Checkout/i18n/en_GB.csv
@@ -204,3 +204,6 @@
 "Labels could not be generated. %1","Labels could not be generated. %1"
 "If you are not redirected automatically,","If you are not redirected automatically,"
 "click here","click here"
+"Show consign password for Z-BOX","Show consign password for Z-BOX"
+"Consign password","Consign password"
+"Show consign password","Show consign password"

--- a/Packetery/Checkout/i18n/sk_SK.csv
+++ b/Packetery/Checkout/i18n/sk_SK.csv
@@ -204,3 +204,6 @@
 "Labels could not be generated. %1","Štítky sa nepodarilo vygenerovať. %1"
 "If you are not redirected automatically,","Ak nedôjde k automatickému presmerovaniu,"
 "click here","kliknite sem"
+"Show consign password for Z-BOX","Zobraziť heslo pre podanie do Z-BOXu"
+"Consign password","Heslo pre podanie"
+"Show consign password","Zobraziť heslo pre podanie"

--- a/Packetery/Checkout/view/adminhtml/ui_component/packetery_checkout_order_listing.xml
+++ b/Packetery/Checkout/view/adminhtml/ui_component/packetery_checkout_order_listing.xml
@@ -299,6 +299,16 @@
                 </item>
             </argument>
         </column>
+        <column name="consign_password" sortOrder="490" class="Packetery\Checkout\Ui\Component\Order\Listing\Column\ConsignPassword">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="filter" xsi:type="string">text</item>
+                    <item name="dataType" xsi:type="string">text</item>
+                    <item name="label" xsi:type="string" translate="true">Consign password</item>
+                    <item name="visible" xsi:type="boolean">false</item>
+                </item>
+            </argument>
+        </column>
         <actionsColumn name="actions" class="Packetery\Checkout\Ui\Component\Order\Listing\Column\Actions" sortOrder="500">
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">

--- a/Packetery/Checkout/view/adminhtml/ui_component/packetery_order_detail_form.xml
+++ b/Packetery/Checkout/view/adminhtml/ui_component/packetery_order_detail_form.xml
@@ -283,6 +283,18 @@
                 </item>
             </argument>
         </field>
+        <field name="consign_password">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="label" xsi:type="string" translate="true">Consign password</item>
+                    <item name="dataType" xsi:type="string">text</item>
+                    <item name="visible" xsi:type="boolean">true</item>
+                    <item name="disabled" xsi:type="boolean">true</item>
+                    <item name="formElement" xsi:type="string">input</item>
+                    <item name="dataScope" xsi:type="string">consign_password</item>
+                </item>
+            </argument>
+        </field>
         <fieldset name="misc">
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
@@ -399,6 +411,33 @@
                         <item name="additionalClasses" xsi:type="string">hidden</item>
                     </item>
                 </argument>
+            </field>
+            <field name="showConsignPassword">
+                <argument name="data" xsi:type="array">
+                    <item name="config" xsi:type="array">
+                        <item name="dataType" xsi:type="string">text</item>
+                        <item name="label" xsi:type="string" translate="true">Show consign password</item>
+                        <item name="visible" xsi:type="boolean">true</item>
+                        <item name="formElement" xsi:type="string">input</item>
+                        <item name="dataScope" xsi:type="string">showConsignPassword</item>
+                    </item>
+                </argument>
+                <settings>
+                    <switcherConfig>
+                        <rules>
+                            <rule name="0">
+                                <value>0</value>
+                                <actions>
+                                    <action name="0">
+                                        <target>packetery_order_detail_form.areas.general.general.consign_password</target>
+                                        <callback>hide</callback>
+                                    </action>
+                                </actions>
+                            </rule>
+                        </rules>
+                        <enabled>true</enabled>
+                    </switcherConfig>
+                </settings>
             </field>
         </fieldset>
     </fieldset>


### PR DESCRIPTION
JIRA: https://packeta.atlassian.net/browse/PES-3150

## Summary
- Display the Z-BOX consign password in the Packeta order detail and order list, gated by a new "Show consign password for Z-BOX" setting (default off).
- Fetch the password via the `packetInfo()` API during packet submission, store it on the packet, and clear it when the packet is cancelled.
