### PR TITLE
PES-3211: align shipment list footer End under first column

### DIFF
--- a/Packetery/Checkout/view/adminhtml/templates/order_collection_print.phtml
+++ b/Packetery/Checkout/view/adminhtml/templates/order_collection_print.phtml
@@ -99,9 +99,12 @@ $printedAt = new \DateTimeImmutable('now');
                     </tr>
                 <?php endforeach; ?>
                 <tr>
-                    <td colspan="<?= (int) $columnCount ?>">
+                    <td>
                         <div class="packetery-end"><?= $block->escapeHtml(__('End')) ?></div>
                     </td>
+                    <?php for ($column = 1; $column < $columnCount; $column++): ?>
+                        <td class="packetery-end-empty"></td>
+                    <?php endfor; ?>
                 </tr>
                 </tbody>
             </table>

--- a/Packetery/Checkout/view/adminhtml/web/css/order-collection-print.css
+++ b/Packetery/Checkout/view/adminhtml/web/css/order-collection-print.css
@@ -5,6 +5,10 @@
     text-align: center;
     overflow: hidden;
 }
+#packetery-order-collection-print .packetery-end-empty {
+    border: 0 none;
+    background: none;
+}
 #packetery-order-collection-print thead {
     display: table-header-group;
 }


### PR DESCRIPTION
[PES-3211](https://packeta.atlassian.net/browse/PES-3211)

Aligns the "End" footer row of the printable shipment list report under the first column instead of spanning the full table width, filling the remaining columns with borderless empty cells to keep a valid table cell count.


[PES-3211]: https://packeta.atlassian.net/browse/PES-3211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ