### PR TITLE
PES-3245: Fix double API call on single label print error

### DIFF
--- a/Packetery/Checkout/Controller/Adminhtml/Packet/PrintLabel.php
+++ b/Packetery/Checkout/Controller/Adminhtml/Packet/PrintLabel.php
@@ -6,8 +6,10 @@ namespace Packetery\Checkout\Controller\Adminhtml\Packet;
 
 use Magento\Backend\App\Action;
 use Magento\Backend\App\Action\Context;
+use Magento\Framework\Controller\Result\JsonFactory;
 use Magento\Framework\Controller\Result\RawFactory;
-use Magento\Framework\Controller\Result\Redirect;
+use Magento\Framework\Controller\ResultInterface;
+use Magento\Framework\Phrase;
 use Magento\Sales\Model\OrderFactory;
 use Packetery\Checkout\Model\Api\PacketLabelException;
 use Packetery\Checkout\Model\Misc\ComboPhrase;
@@ -21,6 +23,9 @@ class PrintLabel extends Action
 
     /** @var RawFactory */
     private $resultRawFactory;
+
+    /** @var JsonFactory */
+    private $resultJsonFactory;
 
     /** @var PacketeryOrderCollectionFactory */
     private $packeteryOrderCollectionFactory;
@@ -40,6 +45,7 @@ class PrintLabel extends Action
     public function __construct(
         Context $context,
         RawFactory $resultRawFactory,
+        JsonFactory $resultJsonFactory,
         PacketeryOrderCollectionFactory $packeteryOrderCollectionFactory,
         OrderFactory $magentoOrderFactory,
         PacketLabelPrinter $packetLabelPrinter,
@@ -48,6 +54,7 @@ class PrintLabel extends Action
     ) {
         parent::__construct($context);
         $this->resultRawFactory = $resultRawFactory;
+        $this->resultJsonFactory = $resultJsonFactory;
         $this->packeteryOrderCollectionFactory = $packeteryOrderCollectionFactory;
         $this->magentoOrderFactory = $magentoOrderFactory;
         $this->packetLabelPrinter = $packetLabelPrinter;
@@ -56,31 +63,27 @@ class PrintLabel extends Action
     }
 
     /**
-     * @return \Magento\Framework\Controller\Result\Raw|Redirect
+     * @return \Magento\Framework\Controller\Result\Raw|ResultInterface
      */
     public function execute()
     {
-        $resultRedirect = $this->resultRedirectFactory->create()->setPath('packetery/order/index');
         $orderId = (int) $this->getRequest()->getParam('order_id');
         if ($orderId <= 0) {
-            $this->messageManager->addErrorMessage(__('Order not found'));
-            return $resultRedirect;
+            return $this->createErrorResult(__('Order not found'));
         }
 
         $collection = $this->packeteryOrderCollectionFactory->create();
         $collection->addFieldToFilter('id', $orderId);
         $packeteryOrder = $collection->getFirstItem();
         if (!$packeteryOrder->getId()) {
-            $this->messageManager->addErrorMessage(__('Order not found'));
-            return $resultRedirect;
+            return $this->createErrorResult(__('Order not found'));
         }
 
         $magentoOrder = $this->magentoOrderFactory->create()->loadByIncrementId($packeteryOrder->getOrderNumber());
         if (!$magentoOrder->getId()) {
-            $this->messageManager->addErrorMessage(
+            return $this->createErrorResult(
                 __('Order %1 not found.', $packeteryOrder->getOrderNumber())
             );
-            return $resultRedirect;
         }
 
         $offset = (int) $this->getRequest()->getParam('offset');
@@ -98,7 +101,7 @@ class PrintLabel extends Action
                 $this->apiErrorFormatter->format($exception->getMessage(), $errors)
             );
 
-            $this->messageManager->addErrorMessage(
+            return $this->createErrorResult(
                 new ComboPhrase(
                     [
                         __('The label could not be generated.'),
@@ -107,11 +110,8 @@ class PrintLabel extends Action
                     ]
                 )
             );
-
-            return $resultRedirect;
         } catch (PacketLabelLocalizedException $exception) {
-            $this->messageManager->addErrorMessage($exception->getMessage());
-            return $resultRedirect;
+            return $this->createErrorResult($exception->getMessage());
         }
 
         $this->logWriter->logSuccess(
@@ -132,5 +132,27 @@ class PrintLabel extends Action
         $raw->setContents($contents);
 
         return $raw;
+    }
+
+    /**
+     * For the modal (AJAX) flow the message must stay out of the session,
+     * otherwise it would pop up on an unrelated page load later.
+     *
+     * @param Phrase|string $message
+     */
+    private function createErrorResult($message): ResultInterface
+    {
+        $request = $this->getRequest();
+        if ($request instanceof \Magento\Framework\App\Request\Http && $request->isXmlHttpRequest()) {
+            return $this->resultJsonFactory->create()->setData(
+                [
+                    'message' => (string) $message,
+                ]
+            );
+        }
+
+        $this->messageManager->addErrorMessage($message);
+
+        return $this->resultRedirectFactory->create()->setPath('packetery/order/index');
     }
 }

--- a/Packetery/Checkout/view/adminhtml/web/css/styles.css
+++ b/Packetery/Checkout/view/adminhtml/web/css/styles.css
@@ -55,3 +55,7 @@
 .packetery-log-status-success {
     color: #3c763d;
 }
+
+.packetery-print-label-page > .message {
+    margin: 1.5rem 0 2.5rem;
+}

--- a/Packetery/Checkout/view/adminhtml/web/js/grid/columns/actions.js
+++ b/Packetery/Checkout/view/adminhtml/web/js/grid/columns/actions.js
@@ -104,44 +104,97 @@ define([
             var form = $(formElement),
                 action = form.attr('action'),
                 query = form.serialize(),
-                requestUrl = action + (action.indexOf('?') === -1 ? '?' : '&') + query;
+                requestUrl = action + (action.indexOf('?') === -1 ? '?' : '&') + query,
+                backUrl = form.find('.packetery-print-label-cancel').attr('href') || window.location.href;
 
             this.packeteryPrintInProgress = true;
+            this.removePrintLabelFormError();
             this.setPrintLoadingState(true);
             this.setModalInteractionLock(true);
-            $.ajax({
-                url: requestUrl,
-                method: 'GET',
-                xhrFields: {
-                    responseType: 'blob'
+            // 'manual' keeps unexpected redirects (expired session) unfollowed,
+            // errors arrive as JSON thanks to the AJAX header.
+            window.fetch(requestUrl, {
+                redirect: 'manual',
+                headers: {
+                    'X-Requested-With': 'XMLHttpRequest'
                 }
-            }).done(function (responseBlob, textStatus, jqXhr) {
-                var contentType = jqXhr.getResponseHeader('Content-Type') || '',
-                    blobUrl = null;
+            }).then(function (response) {
+                var contentType = response.headers.get('Content-Type') || '';
 
-                if (contentType.indexOf('application/pdf') === -1) {
-                    this.setPrintLoadingState(false);
-                    this.packeteryPrintInProgress = false;
-                    this.setModalInteractionLock(false);
+                if (response.type === 'opaqueredirect') {
+                    this.resetPrintRequestState();
                     this.closePacketeryPrintLabelModal();
-                    window.location.href = requestUrl;
+                    window.location.href = backUrl;
 
+                    return null;
+                }
+
+                if (contentType.indexOf('application/json') !== -1) {
+                    return response.json().then(function (data) {
+                        if (data.ajaxExpired && data.ajaxRedirect) {
+                            this.resetPrintRequestState();
+                            this.closePacketeryPrintLabelModal();
+                            window.location.href = data.ajaxRedirect;
+
+                            return null;
+                        }
+
+                        this.resetPrintRequestState();
+                        this.renderPrintLabelFormError(data.message || $.mage.__('The label could not be generated.'));
+
+                        return null;
+                    }.bind(this));
+                }
+
+                if (!response.ok || contentType.indexOf('application/pdf') === -1) {
+                    this.resetPrintRequestState();
+                    this.renderPrintLabelFormError($.mage.__('The label could not be generated.'));
+
+                    return null;
+                }
+
+                return response.blob();
+            }.bind(this)).then(function (responseBlob) {
+                var blobUrl = null;
+
+                if (responseBlob === null) {
                     return;
                 }
 
                 blobUrl = URL.createObjectURL(responseBlob);
                 window.open(blobUrl, '_blank');
-                this.setPrintLoadingState(false);
-                this.packeteryPrintInProgress = false;
-                this.setModalInteractionLock(false);
+                this.resetPrintRequestState();
                 this.closePacketeryPrintLabelModal();
-            }.bind(this)).fail(function () {
-                this.setPrintLoadingState(false);
-                this.packeteryPrintInProgress = false;
-                this.setModalInteractionLock(false);
-                this.closePacketeryPrintLabelModal();
-                window.location.href = requestUrl;
+            }.bind(this)).catch(function () {
+                this.resetPrintRequestState();
+                this.renderPrintLabelFormError($.mage.__('The label could not be generated.'));
             }.bind(this));
+        },
+
+        renderPrintLabelFormError: function (message) {
+            var page = this.getPacketeryPrintLabelModalContent().find('.packetery-print-label-page'),
+                messageElement = null;
+
+            if (page.length === 0) {
+                this.renderModalError(message);
+
+                return;
+            }
+
+            messageElement = $(this.buildMessageHtml('error', ''));
+            messageElement.children('div').text(message);
+            this.removePrintLabelFormError();
+            page.find('form').before(messageElement);
+        },
+
+        removePrintLabelFormError: function () {
+            this.getPacketeryPrintLabelModalContent().find('.packetery-print-label-page > .message').remove();
+        },
+
+        resetPrintRequestState: function () {
+            this.setPrintLoadingState(false);
+            this.packeteryPrintInProgress = false;
+            this.setModalInteractionLock(false);
         },
 
         setPrintLoadingState: function (isLoading) {


### PR DESCRIPTION
[PES-3245](https://packeta.atlassian.net/browse/PES-3245)

Single label print via the offset modal no longer re-navigates to the print URL on error, so a failed print fires exactly one API call and creates one action-log entry. The API error is now shown inside the modal above the form (AJAX JSON response), while the success path and the direct print link stay unchanged.


[PES-3245]: https://packeta.atlassian.net/browse/PES-3245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ