### PR TITLE
PES-3247: add unit tests for shipment detail tab

### DIFF
--- a/Packetery/Checkout/Test/BaseTest.php
+++ b/Packetery/Checkout/Test/BaseTest.php
@@ -8,6 +8,9 @@ use PHPUnit\Framework\MockObject\MockObject;
 
 abstract class BaseTest extends \PHPUnit\Framework\TestCase
 {
+    protected const SHIPPING_PICKUP_POINT = 'packetery_pickupPointDelivery';
+    protected const SHIPPING_ADDRESS_DELIVERY = 'packeteryPacketaDynamic_106-directAddressDelivery';
+    protected const SHIPPING_NON_PACKETERY = 'dummy_dummy';
 
     /**
      * @param $object
@@ -111,5 +114,56 @@ abstract class BaseTest extends \PHPUnit\Framework\TestCase
         }
 
         return $service;
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\MockObject\Exception
+     */
+    protected function prepareOrderMock(
+        ?string $shippingMethod = null,
+        ?string $shippingCountryId = null,
+        int $storeId = 1
+    ): \Magento\Sales\Model\Order&MockObject {
+        $order = $this->createMock(\Magento\Sales\Model\Order::class);
+
+        $order->method('getShippingMethod')
+            ->willReturn($shippingMethod);
+        $order->method('getStoreId')
+            ->willReturn($storeId);
+
+        $shippingAddress = null;
+        if ($shippingCountryId !== null) {
+            $shippingAddress = $this->createStub(\Magento\Sales\Api\Data\OrderAddressInterface::class);
+            $shippingAddress->method('getCountryId')
+                ->willReturn($shippingCountryId);
+        }
+
+        $order->method('getShippingAddress')
+            ->willReturn($shippingAddress);
+
+        return $order;
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\MockObject\Exception
+     */
+    protected function prepareBoxStub(
+        int $id = 1,
+        string $name = 'M',
+        ?float $depth = null,
+        ?float $width = null,
+        ?float $height = null,
+        bool $deleted = false
+    ): \Packetery\Checkout\Model\Box {
+        $box = $this->createStub(\Packetery\Checkout\Model\Box::class);
+
+        $box->method('getId')->willReturn($id);
+        $box->method('getName')->willReturn($name);
+        $box->method('getDepth')->willReturn($depth);
+        $box->method('getWidth')->willReturn($width);
+        $box->method('getHeight')->willReturn($height);
+        $box->method('getDeleted')->willReturn($deleted);
+
+        return $box;
     }
 }

--- a/Packetery/Checkout/Test/Unit/Block/Adminhtml/Order/View/Tab/PacketeryTest.php
+++ b/Packetery/Checkout/Test/Unit/Block/Adminhtml/Order/View/Tab/PacketeryTest.php
@@ -4,16 +4,28 @@ declare(strict_types=1);
 
 namespace Packetery\Checkout\Test\Unit\Block\Adminhtml\Order\View\Tab;
 
-use Magento\Sales\Api\Data\OrderAddressInterface;
-use Magento\Sales\Model\Order;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Sales\Api\OrderRepositoryInterface;
 use Packetery\Checkout\Block\Adminhtml\Order\View\Tab\Packetery;
+use Packetery\Checkout\Model\Dimensions\Converter;
+use Packetery\Checkout\Model\Packet;
+use Packetery\Checkout\Model\Packet\TrackingUrlFactory;
+use Packetery\Checkout\Model\PacketRepository;
+use Packetery\Checkout\Model\ResourceModel\Order\Collection;
+use Packetery\Checkout\Model\ResourceModel\Order\CollectionFactory;
 use Packetery\Checkout\Test\BaseTest;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
 
 #[AllowMockObjectsWithoutExpectations]
 class PacketeryTest extends BaseTest
 {
+    private const PACKET_NUMBER = '1234567890';
+    private const TRACKING_NUMBER = 'Z' . self::PACKET_NUMBER;
+    private const TRACKING_URL = 'https://tracking.packeta.com/' . self::TRACKING_NUMBER;
+
     /**
      * Read-only age verification must be offered exactly where the edit form offers it:
      * own pickup-point delivery into a Packeta base country, never on an external carrier's
@@ -27,21 +39,7 @@ class PacketeryTest extends BaseTest
         bool $isCarrier,
         bool $expected
     ): void {
-        $order = null;
-        if ($hasOrder) {
-            $order = $this->createMock(Order::class);
-            $order->method('getShippingMethod')
-                ->willReturn($shippingMethod);
-
-            $address = null;
-            if ($countryId !== null) {
-                $address = $this->createMock(OrderAddressInterface::class);
-                $address->method('getCountryId')
-                    ->willReturn($countryId);
-            }
-            $order->method('getShippingAddress')
-                ->willReturn($address);
-        }
+        $order = $hasOrder ? $this->prepareOrderMock($shippingMethod, $countryId) : null;
 
         $packeteryOrder = $this->createMock(\Packetery\Checkout\Model\Order::class);
         $packeteryOrder->method('isCarrier')
@@ -71,6 +69,437 @@ class PacketeryTest extends BaseTest
             'non-packetery method → not eligible' => [true, 'flatrate_flatrate', 'CZ', false, false],
             'no shipping address → not eligible' => [true, 'packetery_pickupPointDelivery', null, false, false],
             'no order → not eligible' => [false, null, null, false, false],
+        ];
+    }
+
+    /**
+     * The read-only view is shown exactly when a packet exists for the order (after submission)
+     */
+    public function testIsSubmittedReflectsPacketPresence(): void
+    {
+        $withPacket = $this->createProxy(
+            Packetery::class,
+            [
+                'packet' => $this->createStub(Packet::class),
+                'packetLoaded' => true,
+            ]
+        );
+        $withoutPacket = $this->createProxy(
+            Packetery::class,
+            [
+                'packet' => null,
+                'packetLoaded' => true,
+            ]
+        );
+
+        $this->assertTrue($withPacket->isSubmitted());
+        $this->assertFalse($withoutPacket->isSubmitted());
+    }
+
+    /**
+     * The other tests inject the post-load cache; here the lazy loaders run for real: order_id from
+     * the request to orderRepository->get, then the order_number collection lookup yields the order row
+     *
+     * @throws \ReflectionException
+     */
+    public function testGetPacketeryOrderLoadsThroughCollection(): void
+    {
+        $row = $this->createStub(\Packetery\Checkout\Model\Order::class);
+        $row->method('getId')
+            ->willReturn(5);
+
+        $block = $this->createProxy(
+            Packetery::class,
+            $this->loaderProperties($this->prepareLoadableOrder(), $row)
+        );
+
+        $this->assertSame(5, $block->getPacketeryOrderId());
+    }
+
+    /**
+     * The collection returns a blank row when no packetery_order matches; its falsy id must be
+     * treated as "no order", not as a real row
+     *
+     * @throws \ReflectionException
+     */
+    public function testGetPacketeryOrderTreatsEmptyRowAsNoOrder(): void
+    {
+        $emptyRow = $this->createStub(\Packetery\Checkout\Model\Order::class);
+        $emptyRow->method('getId')
+            ->willReturn(null);
+
+        $block = $this->createProxy(
+            Packetery::class,
+            $this->loaderProperties($this->prepareLoadableOrder(), $emptyRow)
+        );
+
+        $this->assertNull($block->getPacketeryOrder());
+        $this->assertNull($block->getPacketeryOrderId());
+    }
+
+    /**
+     * A deleted Magento order makes orderRepository->get throw; the loader swallows it and the tab
+     * degrades to "no order" instead of bubbling the exception
+     *
+     * @throws \ReflectionException
+     */
+    public function testGetOrderSwallowsMissingMagentoOrder(): void
+    {
+        $request = $this->createStub(RequestInterface::class);
+        $request->method('getParam')
+            ->willReturn('5');
+
+        $orderRepository = $this->createStub(OrderRepositoryInterface::class);
+        $orderRepository->method('get')
+            ->willThrowException(new NoSuchEntityException());
+
+        $block = $this->createProxy(
+            Packetery::class,
+            [
+                '_request' => $request,
+                'orderRepository' => $orderRepository,
+            ]
+        );
+
+        $this->assertNull($block->getPacketeryOrder());
+    }
+
+    /**
+     * isSubmitted driven through the real getPacket chain (collection row to
+     * packetRepository->findLatestByOrderNumber), not the injected packet cache
+     *
+     * @throws \ReflectionException
+     */
+    #[DataProvider('packetPresenceProvider')]
+    public function testIsSubmittedLoadsPacketThroughRepository(bool $hasPacket, bool $expected): void
+    {
+        $row = $this->createStub(\Packetery\Checkout\Model\Order::class);
+        $row->method('getId')
+            ->willReturn(5);
+        $row->method('getOrderNumber')
+            ->willReturn('000000004');
+
+        $packetRepository = $this->createStub(PacketRepository::class);
+        $packetRepository->method('findLatestByOrderNumber')
+            ->willReturn($hasPacket ? $this->createStub(Packet::class) : null);
+
+        $properties = $this->loaderProperties($this->prepareLoadableOrder(), $row);
+        $properties['packetRepository'] = $packetRepository;
+
+        $block = $this->createProxy(Packetery::class, $properties);
+
+        $this->assertSame($expected, $block->isSubmitted());
+    }
+
+    /**
+     * @return array<string, array{bool, bool}>
+     */
+    public static function packetPresenceProvider(): array
+    {
+        return [
+            'packet found is submitted' => [true, true],
+            'no packet is not submitted' => [false, false],
+        ];
+    }
+
+    /**
+     * After submission the packet number becomes the Z-prefixed tracking link;
+     * with no packet there is nothing to link
+     */
+    public function testTrackingUrlAndNumberComeFromPacket(): void
+    {
+        $packet = $this->createStub(Packet::class);
+        $packet->method('getPacketNumber')
+            ->willReturn(self::PACKET_NUMBER);
+
+        $trackingUrlFactory = $this->createStub(TrackingUrlFactory::class);
+        $trackingUrlFactory->method('create')
+            ->willReturn(self::TRACKING_URL);
+        $trackingUrlFactory->method('formatNumber')
+            ->willReturn(self::TRACKING_NUMBER);
+
+        $block = $this->createProxy(
+            Packetery::class,
+            [
+                'packet' => $packet,
+                'packetLoaded' => true,
+                'trackingUrlFactory' => $trackingUrlFactory,
+            ]
+        );
+
+        $this->assertSame(self::TRACKING_URL, $block->getTrackingUrl());
+        $this->assertSame(self::TRACKING_NUMBER, $block->getTrackingNumber());
+
+        $noPacket = $this->createProxy(
+            Packetery::class,
+            [
+                'packet' => null,
+                'packetLoaded' => true,
+                'trackingUrlFactory' => $trackingUrlFactory,
+            ]
+        );
+        $this->assertNull($noPacket->getTrackingUrl());
+        $this->assertNull($noPacket->getTrackingNumber());
+    }
+
+    /**
+     * The read-only dimensions come from the packet snapshot and render only when complete;
+     * any missing snapshot dimension (or no packet) yields no label
+     */
+    #[DataProvider('dimensionsLabelProvider')]
+    public function testGetDimensionsLabel(
+        bool $hasPacket,
+        ?string $name,
+        ?float $depth,
+        ?float $width,
+        ?float $height,
+        ?string $expected
+    ): void {
+        $properties = [
+            'packetLoaded' => true,
+            'dimensionsConverter' => new Converter(),
+        ];
+
+        if ($hasPacket) {
+            $packet = $this->createStub(Packet::class);
+            $packet->method('getBoxName')
+                ->willReturn($name);
+            $packet->method('getBoxDepth')
+                ->willReturn($depth);
+            $packet->method('getBoxWidth')
+                ->willReturn($width);
+            $packet->method('getBoxHeight')
+                ->willReturn($height);
+            $properties['packet'] = $packet;
+        } else {
+            $properties['packet'] = null;
+        }
+
+        $block = $this->createProxy(Packetery::class, $properties);
+
+        $this->assertSame($expected, $block->getDimensionsLabel());
+    }
+
+    /**
+     * @return array<string, array{bool, ?string, ?float, ?float, ?float, ?string}>
+     */
+    public static function dimensionsLabelProvider(): array
+    {
+        return [
+            'complete snapshot renders label' => [
+                true,
+                'M',
+                30.0,
+                20.0,
+                10.0,
+                'M (30 × 20 × 10 cm)',
+            ],
+            'missing depth yields no label' => [
+                true,
+                'M',
+                null,
+                20.0,
+                10.0,
+                null,
+            ],
+            'missing name yields no label' => [
+                true,
+                null,
+                30.0,
+                20.0,
+                10.0,
+                null,
+            ],
+            'no packet yields no label' => [
+                false,
+                null,
+                null,
+                null,
+                null,
+                null,
+            ],
+        ];
+    }
+
+    /**
+     * On a pickup-point order the delivery label is the chosen point name
+     */
+    public function testGetDeliveryLabelForPickupPoint(): void
+    {
+        $magentoOrder = $this->prepareOrderMock(self::SHIPPING_PICKUP_POINT);
+
+        $packeteryOrder = $this->createStub(\Packetery\Checkout\Model\Order::class);
+        $packeteryOrder->method('getPointName')
+            ->willReturn('Praha 1, Václavské náměstí');
+
+        $block = $this->createProxy(
+            Packetery::class,
+            [
+                'magentoOrder' => $magentoOrder,
+                'magentoOrderLoaded' => true,
+                'packeteryOrder' => $packeteryOrder,
+                'packeteryOrderLoaded' => true,
+            ]
+        );
+
+        $this->assertSame('Praha 1, Václavské náměstí', $block->getDeliveryLabel());
+        $this->assertSame('Pick-up point', $block->getDeliveryLabelHeading());
+    }
+
+    /**
+     * On an address-delivery order the label is the recipient address (filtered, comma-joined)
+     * and the heading switches to "Delivery address"
+     */
+    public function testGetDeliveryLabelForAddress(): void
+    {
+        $magentoOrder = $this->prepareOrderMock(self::SHIPPING_ADDRESS_DELIVERY);
+
+        $address = $this->createStub(\Packetery\Checkout\Model\Address::class);
+        $address->method('getStreet')
+            ->willReturn('Václavské náměstí');
+        $address->method('getHouseNumber')
+            ->willReturn('1');
+        $address->method('getCity')
+            ->willReturn('Praha');
+        $address->method('getZip')
+            ->willReturn('11000');
+
+        $packeteryOrder = $this->createStub(\Packetery\Checkout\Model\Order::class);
+        $packeteryOrder->method('getRecipientAddress')
+            ->willReturn($address);
+
+        $block = $this->createProxy(
+            Packetery::class,
+            [
+                'magentoOrder' => $magentoOrder,
+                'magentoOrderLoaded' => true,
+                'packeteryOrder' => $packeteryOrder,
+                'packeteryOrderLoaded' => true,
+            ]
+        );
+
+        $this->assertSame('Václavské náměstí, 1, Praha, 11000', $block->getDeliveryLabel());
+        $this->assertSame('Delivery address', $block->getDeliveryLabelHeading());
+    }
+
+    /**
+     * The tab renders only for a Packeta order: a non-Packeta shipping method or an order
+     * with no packetery_order row hides it, and there is nothing to show with no order at all
+     *
+     * @throws \ReflectionException
+     */
+    #[DataProvider('canShowTabProvider')]
+    public function testCanShowTab(
+        bool $hasOrder,
+        ?string $shippingMethod,
+        bool $hasPacketeryOrder,
+        bool $expected
+    ): void {
+        $order = $hasOrder ? $this->prepareOrderMock($shippingMethod) : null;
+
+        $packeteryOrder = null;
+        if ($hasPacketeryOrder) {
+            $packeteryOrder = $this->createStub(\Packetery\Checkout\Model\Order::class);
+            $packeteryOrder->method('getId')
+                ->willReturn(5);
+        }
+
+        $block = $this->createProxy(
+            Packetery::class,
+            [
+                'magentoOrder' => $order,
+                'magentoOrderLoaded' => true,
+                'packeteryOrder' => $packeteryOrder,
+                'packeteryOrderLoaded' => true,
+            ]
+        );
+
+        $this->assertSame($expected, $block->canShowTab());
+    }
+
+    /**
+     * @return array<string, array{bool, ?string, bool, bool}>
+     */
+    public static function canShowTabProvider(): array
+    {
+        return [
+            'packeta order with row → shown' => [
+                true,
+                self::SHIPPING_PICKUP_POINT,
+                true,
+                true,
+            ],
+            'packeta method but no packetery row → hidden' => [
+                true,
+                self::SHIPPING_PICKUP_POINT,
+                false,
+                false,
+            ],
+            'non-packeta method → hidden' => [
+                true,
+                self::SHIPPING_NON_PACKETERY,
+                true,
+                false,
+            ],
+            'empty shipping method → hidden' => [
+                true,
+                '',
+                true,
+                false,
+            ],
+            'no order → hidden' => [
+                false,
+                null,
+                false,
+                false,
+            ],
+        ];
+    }
+
+    /**
+     * Magento order resolvable through the request/orderRepository loader
+     *
+     * @throws \PHPUnit\Framework\MockObject\Exception
+     */
+    private function prepareLoadableOrder(): \Magento\Sales\Model\Order&MockObject
+    {
+        $order = $this->prepareOrderMock(self::SHIPPING_PICKUP_POINT);
+        $order->method('getIncrementId')
+            ->willReturn('000000004');
+
+        return $order;
+    }
+
+    /**
+     * Properties that wire the lazy loaders: order_id from the request to orderRepository->get,
+     * then the order_number collection lookup returning the given first row
+     *
+     * @return array<string, mixed>
+     */
+    private function loaderProperties(
+        \Magento\Sales\Api\Data\OrderInterface $magentoOrder,
+        \Packetery\Checkout\Model\Order $firstRow
+    ): array {
+        $request = $this->createStub(RequestInterface::class);
+        $request->method('getParam')
+            ->willReturn('5');
+
+        $orderRepository = $this->createStub(OrderRepositoryInterface::class);
+        $orderRepository->method('get')
+            ->willReturn($magentoOrder);
+
+        $collection = $this->createStub(Collection::class);
+        $collection->method('getFirstItem')
+            ->willReturn($firstRow);
+
+        $collectionFactory = $this->createStub(CollectionFactory::class);
+        $collectionFactory->method('create')
+            ->willReturn($collection);
+
+        return [
+            '_request' => $request,
+            'orderRepository' => $orderRepository,
+            'orderCollectionFactory' => $collectionFactory,
         ];
     }
 }

--- a/Packetery/Checkout/Test/Unit/Controller/Adminhtml/Order/SaveTest.php
+++ b/Packetery/Checkout/Test/Unit/Controller/Adminhtml/Order/SaveTest.php
@@ -1,0 +1,309 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Packetery\Checkout\Test\Unit\Controller\Adminhtml\Order;
+
+use Magento\Framework\App\Request\Http;
+use Magento\Framework\Controller\Result\Redirect;
+use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\Locale\FormatInterface;
+use Magento\Framework\Message\ManagerInterface;
+use Magento\Sales\Model\Order as MagentoOrder;
+use Magento\Sales\Model\OrderFactory;
+use Packetery\Checkout\Controller\Adminhtml\Order\Save;
+use Packetery\Checkout\Model\Order as PacketeryOrder;
+use Packetery\Checkout\Model\Packet;
+use Packetery\Checkout\Model\PacketRepository;
+use Packetery\Checkout\Model\ResourceModel\Order\Collection;
+use Packetery\Checkout\Model\ResourceModel\Order\CollectionFactory;
+use Packetery\Checkout\Test\BaseTest;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+
+#[AllowMockObjectsWithoutExpectations]
+class SaveTest extends BaseTest
+{
+    private const ORDER_NUMBER = '000000001';
+
+    /**
+     * Happy path on a pickup-point order: the pickup-point fields persisted, numeric fields parsed,
+     * age-verification checkbox stored as 1, the chosen box id cast to int, and the success message shown
+     */
+    public function testExecuteSavesPickupPointDetails(): void
+    {
+        $context = $this->makeContext(
+            [
+                'id' => '1',
+                'value' => '100',
+                'cod' => '',
+                'weight' => '2.5',
+                'adult_content' => '1',
+                'box_id' => '7',
+                'point_id' => '999',
+                'point_name' => 'Praha 1',
+                'is_carrier' => '0',
+                'carrier_pickup_point' => '',
+            ],
+            null,
+            self::SHIPPING_PICKUP_POINT
+        );
+
+        $context['collection']->expects($this->once())
+            ->method('save');
+        $context['messages']->expects($this->once())
+            ->method('addSuccessMessage');
+        $context['messages']->expects($this->never())
+            ->method('addErrorMessage');
+
+        $context['controller']->execute();
+
+        $point = $this->payloadWithKey($context['payloads'], 'point_id');
+
+        $this->assertSame('999', $point['point_id']);
+        $this->assertSame('Praha 1', $point['point_name']);
+        $this->assertFalse($point['is_carrier']);
+        $this->assertNull($point['carrier_pickup_point']);
+        $this->assertArrayNotHasKey('recipient_street', $point);
+
+        $merged = $this->payloadWithKey($context['payloads'], 'adult_content');
+
+        $this->assertSame(1, $merged['adult_content']);
+        $this->assertSame(7, $merged['box_id']);
+        $this->assertSame(100.0, $merged['value']);
+        $this->assertSame(2.5, $merged['weight']);
+        $this->assertArrayHasKey('cod', $merged);
+        $this->assertNull($merged['cod']);
+    }
+
+    /**
+     * Clearing the box ("-- Select a box --") stores null;
+     * an unchecked age-verification box stores 0
+     */
+    public function testExecuteStoresClearedBoxAndUncheckedAdultContent(): void
+    {
+        $context = $this->makeContext(
+            [
+                'id' => '1',
+                'value' => '0',
+                'cod' => '',
+                'weight' => '',
+                'box_id' => '',
+            ],
+            null,
+            self::SHIPPING_PICKUP_POINT
+        );
+
+        $context['collection']->expects($this->once())
+            ->method('save');
+
+        $context['controller']->execute();
+
+        $merged = $this->payloadWithKey($context['payloads'], 'adult_content');
+        $this->assertNull($merged['box_id']);
+        $this->assertSame(0, $merged['adult_content']);
+        $this->assertSame(0.0, $merged['value']);
+        $this->assertNull($merged['weight']);
+    }
+
+    /**
+     * The form blocks negative input client-side, so a negative number here is an altered request:
+     * reject with the error message and persist nothing
+     */
+    public function testExecuteRejectsNegativeNumericValue(): void
+    {
+        $context = $this->makeContext(
+            [
+                'id' => '1',
+                'value' => '100',
+                'cod' => '',
+                'weight' => '-5',
+            ],
+            null,
+            self::SHIPPING_PICKUP_POINT
+        );
+
+        $context['collection']->expects($this->never())
+            ->method('save');
+        $context['messages']->expects($this->once())
+            ->method('addErrorMessage');
+        $context['messages']->expects($this->never())
+            ->method('addSuccessMessage');
+
+        $context['controller']->execute();
+    }
+
+    /**
+     * The packet is the source of truth once submitted;
+     * POST to the (hidden) form is a stale tab or an altered request and is rejected before any field is touched
+     */
+    public function testExecuteRejectsWhenPacketAlreadySubmitted(): void
+    {
+        $context = $this->makeContext(
+            [
+                'id' => '1',
+                'value' => '100',
+                'cod' => '',
+                'weight' => '2.5',
+            ],
+            $this->createStub(Packet::class),
+            self::SHIPPING_PICKUP_POINT
+        );
+
+        $context['collection']->expects($this->never())
+            ->method('save');
+        $context['messages']->expects($this->once())
+            ->method('addErrorMessage');
+        $context['messages']->expects($this->never())
+            ->method('addSuccessMessage');
+
+        $context['controller']->execute();
+    }
+
+    /**
+     * On an address-delivery order the recipient address is persisted (not the pickup-point fields),
+     * because the delivery type is taken from the order's real shipping method, not the posted flag
+     */
+    public function testExecuteSavesAddressDeliveryDetails(): void
+    {
+        $context = $this->makeContext(
+            [
+                'id' => '1',
+                'value' => '100',
+                'cod' => '',
+                'weight' => '2.5',
+                'recipient_street' => 'Václavské náměstí',
+                'recipient_house_number' => '1',
+                'recipient_city' => 'Praha',
+                'recipient_zip' => '11000',
+                'recipient_country_id' => 'CZ',
+                'point_id' => '999',
+                'point_name' => 'Praha 1',
+            ],
+            null,
+            self::SHIPPING_ADDRESS_DELIVERY
+        );
+
+        $context['collection']->expects($this->once())
+            ->method('save');
+        $context['messages']->expects($this->once())
+            ->method('addSuccessMessage');
+
+        $context['controller']->execute();
+        $delivery = $this->payloadWithKey($context['payloads'], 'recipient_street');
+
+        $this->assertSame('Václavské náměstí', $delivery['recipient_street']);
+        $this->assertSame('Praha', $delivery['recipient_city']);
+        $this->assertSame('11000', $delivery['recipient_zip']);
+        $this->assertSame('CZ', $delivery['recipient_country_id']);
+
+        $this->assertArrayNotHasKey('point_id', $delivery);
+        $this->assertArrayNotHasKey('point_name', $delivery);
+    }
+
+    /**
+     * @param array<string, mixed> $post
+     * @return array{
+     *     controller: Save,
+     *     collection: MockObject,
+     *     messages: MockObject,
+     *     payloads: \stdClass
+     * }
+     */
+    private function makeContext(array $post, ?object $existingPacket, string $shippingMethod): array
+    {
+        $request = $this->createMock(Http::class);
+        $request->method('isPost')
+            ->willReturn(true);
+        $request->method('getPostValue')
+            ->willReturn(['general' => $post]);
+
+        $item = $this->createStub(PacketeryOrder::class);
+        $item->method('getId')
+            ->willReturn(1);
+        $item->method('getOrderNumber')
+            ->willReturn(self::ORDER_NUMBER);
+
+        $payloads = new \stdClass();
+        $payloads->all = [];
+        $collection = $this->createMock(Collection::class);
+        $collection->method('getFirstItem')
+            ->willReturn($item);
+        $collection->method('setDataToAll')
+            ->willReturnCallback(static function (array $data) use ($payloads): void {
+                $payloads->all[] = $data;
+            });
+
+        $collectionFactory = $this->createStub(CollectionFactory::class);
+        $collectionFactory->method('create')
+            ->willReturn($collection);
+
+        $magentoOrder = $this->createMock(MagentoOrder::class);
+        $magentoOrder->method('loadByIncrementId')
+            ->willReturnSelf();
+        $magentoOrder->method('getShippingMethod')
+            ->willReturn($shippingMethod);
+        $magentoOrder->method('getId')
+            ->willReturn(1);
+
+        $orderFactory = $this->createStub(OrderFactory::class);
+        $orderFactory->method('create')
+            ->willReturn($magentoOrder);
+
+        $packetRepository = $this->createStub(PacketRepository::class);
+        $packetRepository->method('findLatestByOrderNumber')
+            ->willReturn($existingPacket);
+
+        $messages = $this->createMock(ManagerInterface::class);
+
+        $redirect = $this->createStub(Redirect::class);
+        $redirect->method('setPath')
+            ->willReturnSelf();
+        $resultFactory = $this->createStub(ResultFactory::class);
+        $resultFactory->method('create')
+            ->willReturn($redirect);
+
+        $localeFormat = $this->createStub(FormatInterface::class);
+        $localeFormat->method('getNumber')
+            ->willReturnCallback(static fn ($value): float => (float) $value);
+
+        $controller = $this->createProxy(
+            Save::class,
+            [
+                'orderCollectionFactory' => $collectionFactory,
+                'orderFactory' => $orderFactory,
+                'packetRepository' => $packetRepository,
+                'logger' => $this->createStub(LoggerInterface::class),
+                'localeFormat' => $localeFormat,
+                '_request' => $request,
+                'messageManager' => $messages,
+                'resultFactory' => $resultFactory,
+            ]
+        );
+
+        return [
+            'controller' => $controller,
+            'collection' => $collection,
+            'messages' => $messages,
+            'payloads' => $payloads,
+        ];
+    }
+
+    /**
+     * Returns the first captured setDataToAll payload carrying $key; execute() calls it twice
+     * (delivery fields, then the numeric+box+adult merge)
+     *
+     * @return array<string, mixed>
+     */
+    private function payloadWithKey(\stdClass $payloads, string $key): array
+    {
+        foreach ($payloads->all as $payload) {
+            if (array_key_exists($key, $payload)) {
+                return $payload;
+            }
+        }
+
+        $this->fail("No setDataToAll payload carrying '{$key}' was captured.");
+    }
+}

--- a/Packetery/Checkout/Test/Unit/Dimensions/ConverterTest.php
+++ b/Packetery/Checkout/Test/Unit/Dimensions/ConverterTest.php
@@ -46,6 +46,9 @@ class ConverterTest extends TestCase
             'whole number drops decimals' => [30.0, '30'],
             'keeps one decimal' => [30.5, '30.5'],
             'trims trailing zero' => [20.0, '20'],
+            'negative whole trims decimals' => [-5.0, '-5'],
+            'negative keeps one decimal' => [-12.5, '-12.5'],
+            'rounds to one decimal' => [30.25, '30.3'],
         ];
     }
 

--- a/Packetery/Checkout/Test/Unit/Model/Packet/PacketSubmitterTest.php
+++ b/Packetery/Checkout/Test/Unit/Model/Packet/PacketSubmitterTest.php
@@ -20,17 +20,22 @@ use Packetery\Checkout\Model\ResourceModel\Packet\CollectionFactory as PacketCol
 use Packetery\Checkout\Model\Weight\Calculator;
 use Packetery\Checkout\Test\BaseTest;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 
 #[AllowMockObjectsWithoutExpectations]
 class PacketSubmitterTest extends BaseTest
 {
+    private const DEFAULT_WEIGHT = 3.5;
+    private const PACKET_NUMBER = 'PKT-1';
+    private const CONSIGN_PASSWORD = 'A1B2C3';
+
     /**
      * @throws \ReflectionException
      */
     public function testResolveWeightPrefersManualWeight(): void
     {
-        $this->assertSame(3.5, $this->invokeResolveWeight(3.5, 1.2, 2.0));
+        $this->assertSame(self::DEFAULT_WEIGHT, $this->invokeResolveWeight(self::DEFAULT_WEIGHT, 1.2, 2.0));
     }
 
     /**
@@ -74,14 +79,14 @@ class PacketSubmitterTest extends BaseTest
         $packeteryOrder->expects($this->once())->method('markExported');
 
         $soapApiClient = $this->createMock(SoapApiClient::class);
-        $soapApiClient->method('createPacket')->willReturn(new CreatePacketResult('PKT-1'));
+        $soapApiClient->method('createPacket')->willReturn(new CreatePacketResult(self::PACKET_NUMBER));
 
         $submitter = $this->makeSubmitter($soapApiClient, $orderResource);
 
-        $submitter->submitPacket($packeteryOrder, $this->makeMagentoOrder());
+        $submitter->submitPacket($packeteryOrder, $this->prepareOrderMock(self::SHIPPING_PICKUP_POINT));
 
         // setWeight is a DataObject magic setter, so the write-back is read back off the raw data
-        $this->assertSame(3.5, $packeteryOrder->getData('weight'));
+        $this->assertSame(self::DEFAULT_WEIGHT, $packeteryOrder->getData('weight'));
     }
 
     /**
@@ -95,7 +100,7 @@ class PacketSubmitterTest extends BaseTest
         $orderResource->expects($this->never())
             ->method('save');
 
-        $packeteryOrder = $this->makePacketeryOrder(3.5);
+        $packeteryOrder = $this->makePacketeryOrder(self::DEFAULT_WEIGHT);
         $packeteryOrder->expects($this->never())
             ->method('markExported');
 
@@ -108,7 +113,7 @@ class PacketSubmitterTest extends BaseTest
         $this->assertException(
             PacketSubmissionException::class,
             function () use ($submitter, $packeteryOrder): void {
-                $submitter->submitPacket($packeteryOrder, $this->makeMagentoOrder());
+                $submitter->submitPacket($packeteryOrder, $this->prepareOrderMock(self::SHIPPING_PICKUP_POINT));
             }
         );
 
@@ -117,10 +122,8 @@ class PacketSubmitterTest extends BaseTest
     }
 
     /**
-     * No manual weight, no product weight and no configured default:
-     * the resolver does not crash, it stays at 0.0
-     * (see testResolveWeightStaysZeroWhenNothingResolves) and that zero is what reaches the API,
-     * which rejects the packet, so nothing is persisted.
+     * No manual, product, or configured weight: the resolver stays at 0.0; that zero reaches the API,
+     * which rejects the packet, so nothing is persisted
      *
      * @throws \ReflectionException
      */
@@ -151,7 +154,7 @@ class PacketSubmitterTest extends BaseTest
         $this->assertException(
             PacketSubmissionException::class,
             function () use ($submitter, $packeteryOrder): void {
-                $submitter->submitPacket($packeteryOrder, $this->makeMagentoOrder());
+                $submitter->submitPacket($packeteryOrder, $this->prepareOrderMock(self::SHIPPING_PICKUP_POINT));
             }
         );
 
@@ -160,69 +163,276 @@ class PacketSubmitterTest extends BaseTest
     }
 
     /**
-     * A box with all dimensions set sends the size to the API in whole mm (cm × 10),
-     * mapping depth to the API length axis.
-     *
-     * @throws \ReflectionException
+     * @return array<string, array{?float, ?float, ?float, ?array<string, int>}>
      */
-    public function testSubmitPacketSendsBoxSizeInMillimetres(): void
+    public static function boxSizeProvider(): array
     {
-        $box = $this->makeBox(30.0, 20.0, 10.0);
-
-        $sentSize = null;
-        $soapApiClient = $this->createMock(SoapApiClient::class);
-        $soapApiClient->method('createPacket')
-            ->willReturnCallback(
-                function (string $apiPassword, PacketAttributes $attributes) use (&$sentSize): CreatePacketResult {
-                    $sentSize = $attributes->toArray()['size'] ?? null;
-
-                    return new CreatePacketResult('PKT-1');
-                }
-            );
-
-        $submitter = $this->makeSubmitter($soapApiClient, $this->createMock(OrderResource::class), $box);
-
-        $submitter->submitPacket($this->makePacketeryOrder(3.5, 7), $this->makeMagentoOrder());
-
-        $this->assertSame(['length' => 300, 'width' => 200, 'height' => 100], $sentSize);
+        return [
+            'all dimensions → mm (depth maps to API length)' => [
+                30.0,
+                20.0,
+                10.0,
+                ['length' => 300, 'width' => 200, 'height' => 100],
+            ],
+            'null dimension (DB-edited row) → size skipped' => [
+                null,
+                20.0,
+                10.0,
+                null,
+            ],
+        ];
     }
 
     /**
-     * A box dimension is null only on a row edited directly in the database, so the size is skipped
-     * instead of crashing the strict conversion: the packet still submits, just without size.
-     *
+     * @param ?array<string, int> $expectedSize
      * @throws \ReflectionException
      */
-    public function testSubmitPacketSkipsSizeWhenBoxDimensionMissing(): void
-    {
-        $box = $this->makeBox(null, 20.0, 10.0);
+    #[DataProvider('boxSizeProvider')]
+    public function testSubmitBoxSize(
+        ?float $depth,
+        ?float $width,
+        ?float $height,
+        ?array $expectedSize
+    ): void {
+        $box = $this->prepareBoxStub(
+            1,
+            'M',
+            $depth,
+            $width,
+            $height
+        );
 
-        $sizeKeyExists = true;
+        $captured = [];
         $soapApiClient = $this->createMock(SoapApiClient::class);
         $soapApiClient->method('createPacket')
             ->willReturnCallback(
-                function (string $apiPassword, PacketAttributes $attributes) use (&$sizeKeyExists): CreatePacketResult {
-                    $sizeKeyExists = array_key_exists('size', $attributes->toArray());
+                function (string $apiPassword, PacketAttributes $attributes) use (&$captured): CreatePacketResult {
+                    $captured = $attributes->toArray();
 
-                    return new CreatePacketResult('PKT-1');
+                    return new CreatePacketResult(self::PACKET_NUMBER);
                 }
             );
-
         $submitter = $this->makeSubmitter($soapApiClient, $this->createMock(OrderResource::class), $box);
 
-        $submitter->submitPacket($this->makePacketeryOrder(3.5, 7), $this->makeMagentoOrder());
+        $submitter->submitPacket(
+            $this->makePacketeryOrder(self::DEFAULT_WEIGHT, 7),
+            $this->prepareOrderMock(self::SHIPPING_PICKUP_POINT)
+        );
 
-        $this->assertFalse($sizeKeyExists);
+        if ($expectedSize === null) {
+            $this->assertArrayNotHasKey('size', $captured);
+
+            return;
+        }
+
+        $this->assertSame($expectedSize, $captured['size']);
+    }
+
+    /** @return array<string, array{float, ?float}> */
+    public static function codProvider(): array
+    {
+        return [
+            'zero COD omits attribute' => [0.0, null],
+            'positive COD is sent' => [150.0, 150.0],
+        ];
     }
 
     /**
-     * Order with a manual weight so `resolveWeight` short-circuits, on a pickup-point method with no
-     * carrier pickup point, no box, no COD and no adult content, so `submitPacket` takes its shortest path.
-     * Partial mock: the declared getters are stubbed, but the magic setWeight()/getData() stay real
-     * so the test can observe the write-back.
+     * @throws \ReflectionException
      */
-    private function makePacketeryOrder(?float $manualWeight, ?int $boxId = null): MockObject
+    #[DataProvider('codProvider')]
+    public function testSubmitCodAttribute(float $cod, ?float $expectedCod): void
     {
+        $captured = [];
+        $soapApiClient = $this->createMock(SoapApiClient::class);
+        $soapApiClient->method('createPacket')
+            ->willReturnCallback(
+                function (string $apiPassword, PacketAttributes $attributes) use (&$captured): CreatePacketResult {
+                    $captured = $attributes->toArray();
+
+                    return new CreatePacketResult(self::PACKET_NUMBER);
+                }
+            );
+        $submitter = $this->makeSubmitter($soapApiClient, $this->createMock(OrderResource::class));
+
+        $submitter->submitPacket(
+            $this->makePacketeryOrder(
+                self::DEFAULT_WEIGHT,
+                null,
+                100.0,
+                $cod
+            ),
+            $this->prepareOrderMock(self::SHIPPING_PICKUP_POINT)
+        );
+
+        $this->assertSame($expectedCod, $captured['cod'] ?? null);
+    }
+
+    /** @return array<string, array{bool, bool, ?bool}> */
+    public static function adultContentProvider(): array
+    {
+        return [
+            'flag on + own pickup + base country → sent' => [true, false, true],
+            'flag on + carrier pickup → omitted' => [true, true, null],
+            'flag off → omitted' => [false, false, null],
+        ];
+    }
+
+    /**
+     * @throws \ReflectionException
+     */
+    #[DataProvider('adultContentProvider')]
+    public function testSubmitAdultContentAttribute(
+        bool $adultContent,
+        bool $isCarrier,
+        ?bool $expectedAdultContent
+    ): void {
+        $captured = [];
+        $soapApiClient = $this->createMock(SoapApiClient::class);
+        $soapApiClient->method('createPacket')
+            ->willReturnCallback(
+                function (string $apiPassword, PacketAttributes $attributes) use (&$captured): CreatePacketResult {
+                    $captured = $attributes->toArray();
+
+                    return new CreatePacketResult(self::PACKET_NUMBER);
+                }
+            );
+
+        $submitter = $this->makeSubmitter($soapApiClient, $this->createMock(OrderResource::class));
+        $submitter->submitPacket(
+            $this->makePacketeryOrder(
+                self::DEFAULT_WEIGHT,
+                null,
+                100.0,
+                0.0,
+                $adultContent,
+                $isCarrier
+            ),
+            $this->prepareOrderMock(self::SHIPPING_PICKUP_POINT, 'CZ')
+        );
+
+        $this->assertSame($expectedAdultContent, $captured['adultContent'] ?? null);
+    }
+
+    /**
+     * Box is snapshotted onto the packet so the detail stays correct if the box is later changed
+     *
+     * @throws \ReflectionException
+     */
+    public function testSubmitSnapshotsBoxDimensionsOnSuccess(): void
+    {
+        $box = $this->prepareBoxStub(
+            1,
+            'M',
+            30.0,
+            20.0,
+            10.0
+        );
+
+        $packet = $this->createMock(\Packetery\Checkout\Model\Packet::class);
+        $packet->expects($this->once())
+            ->method('setBoxName')
+            ->with('M');
+        $packet->expects($this->once())
+            ->method('setBoxDepth')
+            ->with(30.0);
+        $packet->expects($this->once())
+            ->method('setBoxWidth')
+            ->with(20.0);
+        $packet->expects($this->once())
+            ->method('setBoxHeight')
+            ->with(10.0);
+
+        $soapApiClient = $this->createMock(SoapApiClient::class);
+        $soapApiClient->method('createPacket')
+            ->willReturn(new CreatePacketResult(self::PACKET_NUMBER));
+
+        $submitter = $this->makeSubmitter($soapApiClient, $this->createMock(OrderResource::class), $box, $packet);
+
+        $submitter->submitPacket(
+            $this->makePacketeryOrder(self::DEFAULT_WEIGHT, 7),
+            $this->prepareOrderMock(self::SHIPPING_PICKUP_POINT)
+        );
+    }
+
+    /**
+     * With the consignment code enabled the submit fetches it through packetInfo and stores it on the packet
+     *
+     * @throws \ReflectionException
+     */
+    public function testSubmitFetchesConsignPasswordWhenEnabled(): void
+    {
+        $packetInfo = $this->createStub(\Packetery\Checkout\Model\Api\Result\PacketInfoResult::class);
+        $packetInfo->method('getConsignPassword')
+            ->willReturn(self::CONSIGN_PASSWORD);
+
+        $soapApiClient = $this->createMock(SoapApiClient::class);
+        $soapApiClient->method('createPacket')
+            ->willReturn(new CreatePacketResult(self::PACKET_NUMBER));
+        $soapApiClient->expects($this->once())
+            ->method('packetInfo')
+            ->willReturn($packetInfo);
+
+        $packet = $this->createMock(\Packetery\Checkout\Model\Packet::class);
+        $packet->expects($this->once())
+            ->method('setConsignPassword')
+            ->with(self::CONSIGN_PASSWORD);
+
+        $submitter = $this->makeSubmitter(
+            $soapApiClient,
+            $this->createMock(OrderResource::class),
+            null,
+            $packet,
+            true
+        );
+
+        $submitter->submitPacket(
+            $this->makePacketeryOrder(self::DEFAULT_WEIGHT),
+            $this->prepareOrderMock(self::SHIPPING_PICKUP_POINT)
+        );
+    }
+
+    /**
+     * With the consignment code disabled the submit never calls packetInfo and stores null
+     *
+     * @throws \ReflectionException
+     */
+    public function testSubmitSkipsConsignPasswordWhenDisabled(): void
+    {
+        $soapApiClient = $this->createMock(SoapApiClient::class);
+        $soapApiClient->method('createPacket')
+            ->willReturn(new CreatePacketResult(self::PACKET_NUMBER));
+        $soapApiClient->expects($this->never())
+            ->method('packetInfo');
+
+        $packet = $this->createMock(\Packetery\Checkout\Model\Packet::class);
+        $packet->expects($this->once())
+            ->method('setConsignPassword')
+            ->with(null);
+
+        $submitter = $this->makeSubmitter(
+            $soapApiClient,
+            $this->createMock(OrderResource::class),
+            packet: $packet
+        );
+
+        $submitter->submitPacket(
+            $this->makePacketeryOrder(self::DEFAULT_WEIGHT),
+            $this->prepareOrderMock(self::SHIPPING_PICKUP_POINT)
+        );
+    }
+
+    /**
+     * Partial mock: declared getters are stubbed, magic setWeight()/getData() stay real so tests see the write-back
+     */
+    private function makePacketeryOrder(
+        ?float $manualWeight,
+        ?int $boxId = null,
+        ?float $value = 100.0,
+        ?float $cod = 0.0,
+        bool $adultContent = false,
+        bool $isCarrier = false
+    ): \Packetery\Checkout\Model\Order&MockObject {
         $packeteryOrder = $this->createPartialMock(
             \Packetery\Checkout\Model\Order::class,
             [
@@ -239,13 +449,14 @@ class PacketSubmitterTest extends BaseTest
                 'getCarrierPickupPoint',
                 'getBoxId',
                 'getAdultContent',
+                'isCarrier',
                 'markExported',
             ]
         );
         $packeteryOrder->method('getOrderNumber')->willReturn('000000004');
         $packeteryOrder->method('getWeight')->willReturn($manualWeight);
-        $packeteryOrder->method('getValue')->willReturn(100.0);
-        $packeteryOrder->method('getCod')->willReturn(0.0);
+        $packeteryOrder->method('getValue')->willReturn($value);
+        $packeteryOrder->method('getCod')->willReturn($cod);
         $packeteryOrder->method('getRecipientFirstname')->willReturn('John');
         $packeteryOrder->method('getRecipientLastname')->willReturn('Smith');
         $packeteryOrder->method('getRecipientCompany')->willReturn('');
@@ -254,23 +465,19 @@ class PacketSubmitterTest extends BaseTest
         $packeteryOrder->method('getPointId')->willReturn(123);
         $packeteryOrder->method('getCarrierPickupPoint')->willReturn(null);
         $packeteryOrder->method('getBoxId')->willReturn($boxId);
-        $packeteryOrder->method('getAdultContent')->willReturn(false);
+        $packeteryOrder->method('getAdultContent')->willReturn($adultContent);
+        $packeteryOrder->method('isCarrier')->willReturn($isCarrier);
 
         return $packeteryOrder;
     }
 
-    private function makeMagentoOrder(): MockObject
-    {
-        $magentoOrder = $this->createMock(\Magento\Sales\Model\Order::class);
-        $magentoOrder->method('getStoreId')->willReturn(1);
-        $magentoOrder->method('getShippingMethod')->willReturn('packetery_pickupPointDelivery');
-        $magentoOrder->method('getShippingAddress')->willReturn(null);
-
-        return $magentoOrder;
-    }
-
-    private function makeSubmitter(MockObject $soapApiClient, MockObject $orderResource, ?\Packetery\Checkout\Model\Box $box = null): PacketSubmitter
-    {
+    private function makeSubmitter(
+        MockObject $soapApiClient,
+        MockObject $orderResource,
+        ?\Packetery\Checkout\Model\Box $box = null,
+        ?object $packet = null,
+        bool $showConsignPassword = false
+    ): PacketSubmitter {
         $scopeConfig = $this->createStub(\Magento\Framework\App\Config\ScopeConfigInterface::class);
         $scopeConfig->method('getValue')->willReturn('configured');
 
@@ -280,10 +487,10 @@ class PacketSubmitterTest extends BaseTest
         $packetCollectionFactory->method('create')->willReturn($packetCollection);
 
         $packetFactory = $this->createStub(PacketFactory::class);
-        $packetFactory->method('create')->willReturn($this->createStub(\Packetery\Checkout\Model\Packet::class));
+        $packetFactory->method('create')->willReturn($packet ?? $this->createStub(\Packetery\Checkout\Model\Packet::class));
 
         $config = $this->createStub(Config::class);
-        $config->method('isShowConsignPassword')->willReturn(false);
+        $config->method('isShowConsignPassword')->willReturn($showConsignPassword);
         $facade = $this->createStub(Facade::class);
         $facade->method('getPacketeryCarrierConfig')->willReturn($config);
 
@@ -315,21 +522,6 @@ class PacketSubmitterTest extends BaseTest
                 'orderCurrencyResolver' => $currencyResolver,
             ]
         );
-    }
-
-    /**
-     * A pickup-point order (see makeMagentoOrder) carrying a box, so submitPacket resolves the box and
-     * builds the size from its dimensions; a null dimension models a row edited directly in the database.
-     */
-    private function makeBox(?float $depth, ?float $width, ?float $height): \Packetery\Checkout\Model\Box
-    {
-        $box = $this->createStub(\Packetery\Checkout\Model\Box::class);
-        $box->method('getName')->willReturn('M');
-        $box->method('getDepth')->willReturn($depth);
-        $box->method('getWidth')->willReturn($width);
-        $box->method('getHeight')->willReturn($height);
-
-        return $box;
     }
 
     /**

--- a/Packetery/Checkout/Test/Unit/Model/Weight/CalculatorTest.php
+++ b/Packetery/Checkout/Test/Unit/Model/Weight/CalculatorTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Packetery\Checkout\Test\Unit\Model\Weight;
+
+use Magento\Catalog\Model\Product;
+use Packetery\Checkout\Model\Weight\Calculator;
+use Packetery\Checkout\Model\Weight\Item;
+use Packetery\Checkout\Test\BaseTest;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+
+#[AllowMockObjectsWithoutExpectations]
+class CalculatorTest extends BaseTest
+{
+    public function testSingleItem(): void
+    {
+        $items = [$this->simpleItem(1, 2.5, 1)];
+
+        $this->assertSame(2.5, (new Calculator())->getItemsWeight($items));
+    }
+
+    public function testMultipleUnitsOfOneProduct(): void
+    {
+        $items = [$this->simpleItem(1, 2.0, 3)];
+
+        $this->assertSame(6.0, (new Calculator())->getItemsWeight($items));
+    }
+
+    public function testMultipleProducts(): void
+    {
+        $items = [
+            $this->simpleItem(1, 1.0, 1),
+            $this->simpleItem(2, 0.5, 2),
+        ];
+
+        $this->assertSame(2.0, (new Calculator())->getItemsWeight($items));
+    }
+
+    /**
+     * A configurable's weight is the weight of its ordered simple child
+     * (times the child's own quantity); the wrapper line itself adds nothing
+     */
+    public function testConfigurableUsesChildWeightNotWrapper(): void
+    {
+        $configurable = $this->item(
+            'configurable',
+            $this->product(10, 0.0, false),
+            1,
+            [$this->simpleItem(11, 1.5, 2)]
+        );
+
+        $this->assertSame(3.0, (new Calculator())->getItemsWeight([$configurable]));
+    }
+
+    /**
+     * Virtual products carry no weight, so a virtual simple item adds nothing to the total
+     */
+    public function testVirtualProductWeighsZero(): void
+    {
+        $items = [
+            $this->simpleItem(1, 2.5, 1),
+            $this->item('simple', $this->product(2, 9.9, true), 4),
+        ];
+
+        $this->assertSame(2.5, (new Calculator())->getItemsWeight($items));
+    }
+
+    /**
+     * @param Item[] $children
+     */
+    private function item(
+        string $productType,
+        Product $product,
+        float $quantity,
+        array $children = []
+    ): Item {
+        return new Item(
+            [
+                'product_type' => $productType,
+                'product' => $product,
+                'qty' => $quantity,
+                'children' => $children,
+            ]
+        );
+    }
+
+    private function simpleItem(
+        int $productId,
+        float $weight,
+        float $quantity
+    ): Item
+    {
+        return $this->item(
+            'simple',
+            $this->product($productId, $weight, false),
+            $quantity
+        );
+    }
+
+    private function product(int $id, float $weight, bool $isVirtual): Product
+    {
+        $product = $this->createStub(Product::class);
+        $product->method('getId')
+            ->willReturn($id);
+        $product->method('getWeight')
+            ->willReturn($weight);
+        $product->method('isVirtual')
+            ->willReturn($isVirtual);
+
+        return $product;
+    }
+}

--- a/Packetery/Checkout/Test/Unit/Ui/Component/Order/BoxSelectTest.php
+++ b/Packetery/Checkout/Test/Unit/Ui/Component/Order/BoxSelectTest.php
@@ -4,26 +4,35 @@ declare(strict_types=1);
 
 namespace Packetery\Checkout\Test\Unit\Ui\Component\Order;
 
-use Packetery\Checkout\Model\Box;
 use Packetery\Checkout\Model\Dimensions\Converter;
 use Packetery\Checkout\Model\ResourceModel\Box\Collection;
 use Packetery\Checkout\Model\ResourceModel\Box\CollectionFactory;
+use Packetery\Checkout\Test\BaseTest;
 use Packetery\Checkout\Ui\Component\Order\BoxSelect;
-use PHPUnit\Framework\TestCase;
 
-class BoxSelectTest extends TestCase
+class BoxSelectTest extends BaseTest
 {
     /**
-     * Test return options array.
      * Soft-deleted box stays in the list but is flagged non-selectable / disabled
-     *
-     * @return void
-     * @throws \PHPUnit\Framework\MockObject\Exception
      */
     public function testToOptionArrayFlagsDeletedBoxesAsDisabled(): void
     {
-        $active = $this->createBox(1, 'M', 30.0, 20.0, 10.0, false);
-        $deleted = $this->createBox(2, 'XS', 30.0, 20.0, 10.0, true);
+        $active = $this->prepareBoxStub(
+            1,
+            'M',
+            30.0,
+            20.0,
+            10.0
+        );
+
+        $deleted = $this->prepareBoxStub(
+            2,
+            'XS',
+            30.0,
+            20.0,
+            10.0,
+            true
+        );
 
         $collection = $this->createStub(Collection::class);
         $collection->method('getIterator')
@@ -58,19 +67,13 @@ class BoxSelectTest extends TestCase
      */
     public function testToOptionArrayUsesBareNameWhenDimensionMissing(): void
     {
-        $box = $this->createStub(Box::class);
-        $box->method('getId')
-            ->willReturn(7);
-        $box->method('getName')
-            ->willReturn('Partial');
-        $box->method('getDepth')
-            ->willReturn(null);
-        $box->method('getWidth')
-            ->willReturn(20.0);
-        $box->method('getHeight')
-            ->willReturn(10.0);
-        $box->method('getDeleted')
-            ->willReturn(false);
+        $box = $this->prepareBoxStub(
+            7,
+            'Partial',
+            null,
+            20.0,
+            10.0
+        );
 
         $collection = $this->createStub(Collection::class);
         $collection->method('getIterator')
@@ -94,29 +97,50 @@ class BoxSelectTest extends TestCase
         );
     }
 
-    private function createBox(
-        int $id,
-        string $name,
-        float $depth,
-        float $width,
-        float $height,
-        bool $deleted
-    ): Box {
-        $box = $this->createStub(Box::class);
+    public function testToOptionArrayReturnsEmptyForEmptyCollection(): void
+    {
+        $collection = $this->createStub(Collection::class);
+        $collection->method('getIterator')
+            ->willReturn(new \ArrayIterator([]));
 
-        $box->method('getId')
-            ->willReturn($id);
-        $box->method('getName')
-            ->willReturn($name);
-        $box->method('getDepth')
-            ->willReturn($depth);
-        $box->method('getWidth')
-            ->willReturn($width);
-        $box->method('getHeight')
-            ->willReturn($height);
-        $box->method('getDeleted')
-            ->willReturn($deleted);
+        $collectionFactory = $this->createStub(CollectionFactory::class);
+        $collectionFactory->method('create')
+            ->willReturn($collection);
 
-        return $box;
+        $options = (new BoxSelect($collectionFactory, new Converter()))->toOptionArray();
+
+        $this->assertSame([], $options);
+    }
+
+    public function testToOptionArrayRendersZeroDimensions(): void
+    {
+        $box = $this->prepareBoxStub(
+            9,
+            'Z',
+            0.0,
+            0.0,
+            0.0
+        );
+
+        $collection = $this->createStub(Collection::class);
+        $collection->method('getIterator')
+            ->willReturn(new \ArrayIterator([$box]));
+
+        $collectionFactory = $this->createStub(CollectionFactory::class);
+        $collectionFactory->method('create')
+            ->willReturn($collection);
+
+        $options = (new BoxSelect($collectionFactory, new Converter()))->toOptionArray();
+
+        $this->assertSame(
+            [
+                [
+                    'label' => 'Z (0 × 0 × 0 cm)',
+                    'value' => 9,
+                    'disabled' => false,
+                ],
+            ],
+            $options
+        );
     }
 }

--- a/Packetery/Checkout/Test/Unit/Ui/Order/DataProviderTest.php
+++ b/Packetery/Checkout/Test/Unit/Ui/Order/DataProviderTest.php
@@ -1,0 +1,556 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Packetery\Checkout\Test\Unit\Ui\Order;
+
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Sales\Model\OrderFactory;
+use Packetery\Checkout\Model\BoxRepository;
+use Packetery\Checkout\Model\Carrier\AbstractBrain;
+use Packetery\Checkout\Model\Carrier\AbstractCarrier;
+use Packetery\Checkout\Model\Carrier\AbstractDynamicCarrier;
+use Packetery\Checkout\Model\Carrier\Facade;
+use Packetery\Checkout\Model\Carrier\Imp\Packetery\Config;
+use Packetery\Checkout\Model\OrderCurrencyResolver;
+use Packetery\Checkout\Model\Packet;
+use Packetery\Checkout\Model\PacketRepository;
+use Packetery\Checkout\Model\ResourceModel\Order\Collection;
+use Packetery\Checkout\Test\BaseTest;
+use Packetery\Checkout\Ui\Order\DataProvider;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\DataProvider as DataProviderAttribute;
+
+/**
+ * Relevance/prefill rules live in private DataProvider methods, driven through reflection
+ */
+#[AllowMockObjectsWithoutExpectations]
+class DataProviderTest extends BaseTest
+{
+    private const ORDER_NUMBER = '000000004';
+    private const ORDER_ITEM_ID = 7;
+    private const DEFAULT_BOX_ID = 9;
+
+    /**
+     * COD field shows only when cod > 0 and the carrier allows cash on delivery (cod === 0.0 is not COD)
+     *
+     * @throws \ReflectionException
+     */
+    #[DataProviderAttribute('codEligibilityProvider')]
+    public function testIsCodEligible(?float $cod, ?string $carrierMode, bool $expected): void
+    {
+        $dynamicCarrier = null;
+        if ($carrierMode !== null) {
+            $dynamicCarrier = $this->createStub(AbstractDynamicCarrier::class);
+            $dynamicCarrier->method('disallowsCod')
+                ->willReturn($carrierMode === 'blocks');
+        }
+
+        $provider = $this->createProxy(DataProvider::class);
+
+        $this->assertSame(
+            $expected,
+            $this->invokeMethod($provider, 'isCodEligible', [$cod, $dynamicCarrier])
+        );
+    }
+
+    /**
+     * @return array<string, array{?float, ?string, bool}>
+     */
+    public static function codEligibilityProvider(): array
+    {
+        return [
+            'null cod is not a COD order' => [null, null, false],
+            'zero cod is not a COD order' => [0.0, null, false],
+            'positive cod, no dynamic carrier (own Packeta allows COD)' => [100.0, null, true],
+            'positive cod, carrier allows COD' => [100.0, 'allows', true],
+            'positive cod, carrier blocks COD' => [100.0, 'blocks', false],
+        ];
+    }
+
+    /**
+     * Store-default weight prefill (display only): only when the order has no positive weight,
+     * only when a positive store default exists, and as a string to match the decimal column
+     *
+     * @throws \ReflectionException
+     */
+    #[DataProviderAttribute('defaultWeightPrefillProvider')]
+    public function testResolveDefaultWeightPrefill(
+        ?float $storedWeight,
+        ?float $configDefault,
+        bool $hasConfig,
+        ?string $expected
+    ): void {
+        $config = null;
+        if ($hasConfig) {
+            $config = $this->createStub(Config::class);
+            $config->method('getDefaultWeight')
+                ->willReturn($configDefault);
+        }
+
+        $provider = $this->createProxy(DataProvider::class);
+
+        $this->assertSame(
+            $expected,
+            $this->invokeMethod($provider, 'resolveDefaultWeightPrefill', [$storedWeight, $config])
+        );
+    }
+
+    /**
+     * @return array<string, array{?float, ?float, bool, ?string}>
+     */
+    public static function defaultWeightPrefillProvider(): array
+    {
+        return [
+            'stored positive weight takes precedence over default' => [
+                2.5,
+                5.0,
+                true,
+                null,
+            ],
+            'zero stored weight falls back to default' => [
+                0.0,
+                5.0,
+                true,
+                '5',
+            ],
+            'null stored weight falls back to default' => [
+                null,
+                5.0,
+                true,
+                '5',
+            ],
+            'decimal default kept as string' => [
+                null,
+                2.5,
+                true,
+                '2.5',
+            ],
+            'zero default does not prefill' => [
+                null,
+                0.0,
+                true,
+                null,
+            ],
+            'null default does not prefill' => [
+                null,
+                null,
+                true,
+                null,
+            ],
+            'no packetery config does not prefill' => [
+                0.0,
+                null,
+                false,
+                null,
+            ],
+        ];
+    }
+
+    /**
+     * Store-default box prefill (display only): only when none is chosen and a default box exists;
+     * a missing default (NoSuchEntityException) resolves to null
+     *
+     * @throws \ReflectionException
+     */
+    #[DataProviderAttribute('defaultBoxPrefillProvider')]
+    public function testResolveDefaultBoxPrefill(
+        ?int $currentBoxId,
+        string $defaultBoxMode,
+        ?int $defaultBoxId,
+        ?int $expected
+    ): void {
+        $boxRepository = $this->createStub(BoxRepository::class);
+
+        if ($defaultBoxMode === 'throw') {
+            $boxRepository->method('getDefaultBox')
+                ->willThrowException(new NoSuchEntityException());
+        } elseif ($defaultBoxMode === 'box') {
+            $boxRepository->method('getDefaultBox')
+                ->willReturn($this->prepareBoxStub($defaultBoxId));
+        } else {
+            $boxRepository->method('getDefaultBox')
+                ->willReturn(null);
+        }
+
+        $provider = $this->createProxy(DataProvider::class, ['boxRepository' => $boxRepository]);
+
+        $this->assertSame(
+            $expected,
+            $this->invokeMethod($provider, 'resolveDefaultBoxPrefill', [$currentBoxId])
+        );
+    }
+
+    /**
+     * @return array<string, array{?int, string, ?int, ?int}>
+     */
+    public static function defaultBoxPrefillProvider(): array
+    {
+        return [
+            'box already set, no prefill' => [
+                5,
+                'box',
+                3,
+                null,
+            ],
+            'zero box id treated as unset' => [
+                0,
+                'box',
+                3,
+                3,
+            ],
+            'no box set, default exists' => [
+                null,
+                'box',
+                3,
+                3,
+            ],
+            'no box set, no default' => [
+                null,
+                'null',
+                null,
+                null,
+            ],
+            'no box set, lookup throws' => [
+                null,
+                'throw',
+                null,
+                null,
+            ],
+        ];
+    }
+
+    /**
+     * The Delivery section shows only when it has a picker to offer: a pickup point (any country)
+     * or an address (HD into a CZ/SK country with address validation); otherwise the heading is hidden
+     *
+     * @throws \ReflectionException
+     */
+    #[DataProviderAttribute('deliverySectionVisibilityProvider')]
+    public function testIsDeliverySectionVisible(
+        ?string $shippingMethod,
+        ?string $countryId,
+        bool $hasAddress,
+        bool $expected
+    ): void {
+        $order = $this->prepareOrderMock($shippingMethod, $hasAddress ? $countryId : null);
+
+        $provider = $this->createProxy(DataProvider::class);
+
+        $this->assertSame(
+            $expected,
+            $this->invokeMethod($provider, 'isDeliverySectionVisible', [$order])
+        );
+    }
+
+    /**
+     * @return array<string, array{?string, ?string, bool, bool}>
+     */
+    public static function deliverySectionVisibilityProvider(): array
+    {
+        return [
+            'pickup point CZ visible' => [
+                self::SHIPPING_PICKUP_POINT,
+                'CZ',
+                true,
+                true,
+            ],
+            'pickup point any country visible' => [
+                self::SHIPPING_PICKUP_POINT,
+                'PL',
+                true,
+                true,
+            ],
+            'HD into CZ (address validation) visible' => [
+                self::SHIPPING_ADDRESS_DELIVERY,
+                'CZ',
+                true,
+                true,
+            ],
+            'HD into PL (no address validation) hidden' => [
+                self::SHIPPING_ADDRESS_DELIVERY,
+                'PL',
+                true,
+                false,
+            ],
+            'non-packetery method hidden' => [
+                self::SHIPPING_NON_PACKETERY,
+                'CZ',
+                true,
+                false,
+            ],
+            'pickup point without address hidden' => [
+                self::SHIPPING_PICKUP_POINT,
+                null,
+                false,
+                false,
+            ],
+            'empty shipping method hidden' => [
+                '',
+                'CZ',
+                true,
+                false,
+            ],
+            'null shipping method hidden' => [
+                null,
+                'CZ',
+                true,
+                false,
+            ],
+        ];
+    }
+
+    /**
+     * getMeta appends the order currency (the static form XML can't carry it) as the value/cod field
+     * suffix. Driven through the real order resolution, so a resolveOrderItem/resolveMagentoOrder
+     * regression that drops the order also drops the suffix.
+     *
+     * @throws \ReflectionException
+     */
+    #[DataProviderAttribute('currencySuffixProvider')]
+    public function testGetMetaAddsCurrencySuffix(?string $currency): void
+    {
+        $magentoOrder = $this->prepareOrderMock(self::SHIPPING_PICKUP_POINT, 'CZ');
+        $magentoOrder->method('getIncrementId')
+            ->willReturn('000000004');
+
+        $packeteryOrder = $this->createStub(\Packetery\Checkout\Model\Order::class);
+        $packeteryOrder->method('getOrderNumber')
+            ->willReturn('000000004');
+
+        $collection = $this->createStub(Collection::class);
+        $collection->method('getItems')
+            ->willReturn([$packeteryOrder]);
+
+        $request = $this->createStub(RequestInterface::class);
+        $request->method('getParam')
+            ->willReturn('5');
+
+        $orderRepository = $this->createStub(OrderRepositoryInterface::class);
+        $orderRepository->method('get')
+            ->willReturn($magentoOrder);
+
+        $resolver = $this->createStub(OrderCurrencyResolver::class);
+        $resolver->method('resolve')
+            ->willReturnCallback(
+                static fn (?object $item, ?object $order): ?string =>
+                    $item !== null && $order !== null ? $currency : null
+            );
+
+        $provider = $this->createProxy(
+            DataProvider::class,
+            [
+                'collection' => $collection,
+                'request' => $request,
+                'orderRepository' => $orderRepository,
+                'orderCurrencyResolver' => $resolver,
+                'meta' => [],
+            ]
+        );
+
+        $meta = $provider->getMeta();
+        $packetChildren = $meta['general']['children']['packet']['children'] ?? null;
+
+        if ($currency === null) {
+            $this->assertNull($packetChildren);
+
+            return;
+        }
+
+        $this->assertSame($currency, $packetChildren['value']['arguments']['data']['config']['addafter']);
+        $this->assertSame($currency, $packetChildren['cod']['arguments']['data']['config']['addafter']);
+    }
+
+    /**
+     * @return array<string, array{?string}>
+     */
+    public static function currencySuffixProvider(): array
+    {
+        return [
+            'CZK suffix on value and cod' => ['CZK'],
+            'EUR suffix on value and cod' => ['EUR'],
+            'no currency, no suffix' => [null],
+        ];
+    }
+
+    /**
+     * The isolated tests cover the rules; this drives getData end to end, so a misordered guard
+     * or a wrong argument wiring the carrier into isCodEligible and the prefills is caught too
+     *
+     * @throws \ReflectionException
+     */
+    public function testGetDataAssemblesMiscFlagsAndPrefills(): void
+    {
+        $provider = $this->makeSingleOrderProvider(
+            [
+                'cod' => 150.0,
+                'defaultWeight' => 2.5,
+                'requiresSize' => true,
+                'defaultBoxId' => self::DEFAULT_BOX_ID,
+            ]
+        );
+
+        $general = $provider->getData()[self::ORDER_ITEM_ID]['general'];
+
+        $this->assertNull($general['consign_password']);
+        $this->assertSame('0', $general['misc']['showConsignPassword']);
+        $this->assertSame('2.5', $general['weight']);
+        $this->assertSame(self::DEFAULT_BOX_ID, $general['box_id']);
+        $this->assertSame('1', $general['misc']['isCodEligible']);
+        $this->assertSame('1', $general['misc']['isSizeEligible']);
+        $this->assertSame('0', $general['misc']['isPickupPointDelivery']);
+        $this->assertSame('[]', $general['misc']['widgetVendors']);
+    }
+
+    /**
+     * The box prefill is wired behind two getData guards the isolated test can't see: it runs only
+     * when the carrier requires a size and no packet has been submitted yet
+     *
+     * @throws \ReflectionException
+     */
+    #[DataProviderAttribute('boxPrefillProvider')]
+    public function testGetDataPrefillsBoxOnlyWhenEligible(
+        bool $requiresSize,
+        bool $hasPacket,
+        ?int $currentBoxId,
+        bool $expectPrefill
+    ): void {
+        $provider = $this->makeSingleOrderProvider(
+            [
+                'weight' => 1.0,
+                'currentBoxId' => $currentBoxId,
+                'hasPacket' => $hasPacket,
+                'requiresSize' => $requiresSize,
+                'defaultBoxId' => self::DEFAULT_BOX_ID,
+            ]
+        );
+
+        $general = $provider->getData()[self::ORDER_ITEM_ID]['general'];
+
+        if ($expectPrefill) {
+            $this->assertSame(self::DEFAULT_BOX_ID, $general['box_id']);
+
+            return;
+        }
+
+        $this->assertArrayNotHasKey('box_id', $general);
+    }
+
+    /**
+     * @return array<string, array{bool, bool, ?int, bool}>
+     */
+    public static function boxPrefillProvider(): array
+    {
+        return [
+            'size required, not submitted, no box → prefilled' => [true, false, null, true],
+            'size required but already submitted → no prefill' => [true, true, null, false],
+            'size not required → no prefill' => [false, false, null, false],
+            'size required but box already set → no prefill' => [true, false, 4, false],
+        ];
+    }
+
+    /**
+     * Builds a DataProvider over one packetery_order row wired through the whole getData chain
+     * (Magento order, per-store carrier config, dynamic carrier via the facade brain). Address delivery
+     * keeps the pickup-point widget-vendor branch out of the way.
+     *
+     * @param array{
+     *     weight?: ?float,
+     *     cod?: ?float,
+     *     currentBoxId?: ?int,
+     *     hasPacket?: bool,
+     *     defaultWeight?: ?float,
+     *     disallowsCod?: bool,
+     *     requiresSize?: bool,
+     *     defaultBoxId?: ?int
+     * } $scenario
+     * @throws \PHPUnit\Framework\MockObject\Exception
+     * @throws \ReflectionException
+     */
+    private function makeSingleOrderProvider(array $scenario): DataProvider
+    {
+        $weight = $scenario['weight'] ?? null;
+        $cod = $scenario['cod'] ?? null;
+        $currentBoxId = $scenario['currentBoxId'] ?? null;
+        $hasPacket = $scenario['hasPacket'] ?? false;
+        $defaultWeight = $scenario['defaultWeight'] ?? null;
+        $disallowsCod = $scenario['disallowsCod'] ?? false;
+        $requiresSize = $scenario['requiresSize'] ?? false;
+        $defaultBoxId = $scenario['defaultBoxId'] ?? null;
+
+        $item = $this->createStub(\Packetery\Checkout\Model\Order::class);
+        $item->method('getId')
+            ->willReturn(self::ORDER_ITEM_ID);
+        $item->method('getData')
+            ->willReturn(['order_number' => self::ORDER_NUMBER]);
+        $item->method('getWeight')
+            ->willReturn($weight);
+        $item->method('getCod')
+            ->willReturn($cod);
+        $item->method('getBoxId')
+            ->willReturn($currentBoxId);
+        $item->method('isCarrier')
+            ->willReturn(false);
+
+        $collection = $this->createStub(Collection::class);
+        $collection->method('getItems')
+            ->willReturn([$item]);
+
+        $packetRepository = $this->createStub(PacketRepository::class);
+        $packetRepository->method('findLatestByOrderNumber')
+            ->willReturn($hasPacket ? $this->createStub(Packet::class) : null);
+
+        $magentoOrder = $this->prepareOrderMock(self::SHIPPING_ADDRESS_DELIVERY, 'CZ');
+        $magentoOrder->method('getIncrementId')
+            ->willReturn(self::ORDER_NUMBER);
+        $magentoOrder->method('loadByIncrementId')
+            ->willReturnSelf();
+
+        $orderFactory = $this->createStub(OrderFactory::class);
+        $orderFactory->method('create')
+            ->willReturn($magentoOrder);
+
+        $config = $this->createStub(Config::class);
+        $config->method('isShowConsignPassword')
+            ->willReturn(false);
+        $config->method('getDefaultWeight')
+            ->willReturn($defaultWeight);
+
+        $dynamicCarrier = $this->createStub(AbstractDynamicCarrier::class);
+        $dynamicCarrier->method('disallowsCod')
+            ->willReturn($disallowsCod);
+        $dynamicCarrier->method('requiresSize')
+            ->willReturn($requiresSize);
+
+        $brain = $this->createStub(AbstractBrain::class);
+        $brain->method('getDynamicCarrierById')
+            ->willReturn($dynamicCarrier);
+
+        $carrier = $this->createStub(AbstractCarrier::class);
+        $carrier->method('getPacketeryBrain')
+            ->willReturn($brain);
+
+        $facade = $this->createStub(Facade::class);
+        $facade->method('getPacketeryCarrierConfig')
+            ->willReturn($config);
+        $facade->method('getMagentoCarrier')
+            ->willReturn($carrier);
+
+        $boxRepository = $this->createStub(BoxRepository::class);
+        $boxRepository->method('getDefaultBox')
+            ->willReturn($defaultBoxId !== null ? $this->prepareBoxStub($defaultBoxId) : null);
+
+        return $this->createProxy(
+            DataProvider::class,
+            [
+                'collection' => $collection,
+                'packetRepository' => $packetRepository,
+                'orderFactory' => $orderFactory,
+                'carrierFacade' => $facade,
+                'boxRepository' => $boxRepository,
+            ]
+        );
+    }
+}


### PR DESCRIPTION
- Doplnění unit testů pro izolovanou serverovou logiku detailu zásilky (záložka „Packeta", PES-2146).
- **Jen testy — produkční kód beze změny.**
- AC1: celá sada na PHPUnit 12 / PHP 8.5, OK (258 testů / 540 assertions)

### Struktura (4 commity podle účelu)
1. sdílená test infrastruktura a konstanty v BaseTest
2. edity existujících test tříd (submit + detail-tab)
3. nové AC třídy (weight, data-provider, save)
4. drobná zlepšení pokrytí nad rámec AC:

| Co ověřuje | Test | Důvod |
|------------|------|-------|
| Box dropdown: prázdná kolekce, nulové rozměry | `Ui/Component/Order/BoxSelectTest` (+2 metody) | datová vrstva, na níž detail stojí |
| Konverze rozměrů: záporné + zaokrouhlení | `Dimensions/ConverterTest` (+3 řádky provideru) | konvertor použitý v detailu |

### Pokrytí vs. zadání

| AC | Co ověřuje | Test |
|----|------------|------|
| 2 | Qty-aware hmotnost: 1 ks, víc ks, víc produktů, configurable, virtual=0 | `Model/Weight/CalculatorTest` |
| 3 | COD matice: bez → skryto, umožňuje → zobrazeno, neumožňuje → skryto | `Ui/Order/DataProviderTest::testIsCodEligible` |
| 4 | Prefill hmotnosti, prefill krabice, skrytí Delivery mimo CZ/SK, měnový suffix | `Ui/Order/DataProviderTest` (4 metody) |
| 5 | Viditelnost záložky: Packeta vs ne-Packeta | `Block/Adminhtml/Order/View/Tab/PacketeryTest::testCanShowTab` |
| 6 | Read-only výpis: doručení (PUDO i adresa), rozměry, tracking (podáno/nepodáno), „podáno" | `Block/Adminhtml/Order/View/Tab/PacketeryTest` (5 metod) |
| 7 | Ukládání: persistence, odmítnutí <0, odmítnutí po podání, obě větve (PUDO i adresa) | `Controller/Adminhtml/Order/SaveTest` (5 metod) |
| 8 | Odeslání: snapshot krabice, ověření věku, COD>0, consign password (on/off) | `Model/Packet/PacketSubmitterTest` |




