### PR TITLE
PES-3213: declare PHP 8.1-8.5 & Magento 2.4.9 support, add phpcs:85

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Price rules are created as unavailable, without set maximum weight.
 
 #### PHP Compatibility Checks
 
-The module includes PHPCompatibility checks to ensure compatibility with PHP 8.1 and PHP 8.4.
+The module includes PHPCompatibility checks to ensure compatibility with PHP 8.1 through PHP 8.5.
 
 Requirements to run the checks: PHP 8.4 and Composer 2.8.6. From the module directory (where `composer.json` lives), run:
 
@@ -63,6 +63,7 @@ Requirements to run the checks: PHP 8.4 and Composer 2.8.6. From the module dire
 composer install
 composer phpcs-compatibility:81  # Check PHP 8.1 compatibility
 composer phpcs-compatibility:84  # Check PHP 8.4 compatibility
+composer phpcs-compatibility:85  # Check PHP 8.5 compatibility
 ```
 
 These commands use PHP_CodeSniffer with the PHPCompatibility standard to detect compatibility issues.
@@ -178,8 +179,8 @@ Behaviour: unset defaults to `30`; a positive integer `N` deletes records older 
 
 #### Supported versions:
 
-- Magento 2.4.4+
-- php 8.1 - 8.4
+- Magento 2.4.4+ (including 2.4.9)
+- php 8.1 - 8.5
 - If you have a problem using the module, please contact us by email: [e-commerce.support@packeta.com](mailto:e-commerce.support@packeta.com)
 
 #### Supported features:
@@ -263,7 +264,7 @@ Cenová pravidla jsou vytvořena jako nedostupná, bez nastavené maximální hm
 
 #### Kontrola kompatibility PHP
 
-Modul obsahuje kontroly PHPCompatibility pro zajištění kompatibility s PHP 8.1 a PHP 8.4.
+Modul obsahuje kontroly PHPCompatibility pro zajištění kompatibility s PHP 8.1 až PHP 8.5.
 
 Pro spuštění kontrol je potřeba PHP 8.4 a Composer 2.8.6. V adresáři modulu (kde je `composer.json`) spusťte:
 
@@ -271,6 +272,7 @@ Pro spuštění kontrol je potřeba PHP 8.4 a Composer 2.8.6. V adresáři modul
 composer install
 composer phpcs-compatibility:81  # Kontrola kompatibility s PHP 8.1
 composer phpcs-compatibility:84  # Kontrola kompatibility s PHP 8.4
+composer phpcs-compatibility:85  # Kontrola kompatibility s PHP 8.5
 ```
 
 Tyto příkazy používají PHP_CodeSniffer se standardem PHPCompatibility pro detekci problémů s kompatibilitou.
@@ -388,8 +390,8 @@ Chování: nenastaveno → výchozí `30`; kladné číslo `N` → denně se ma�
 
 #### Podporované verze:
 
-- Magento 2.4.4+
-- php 8.1 - 8.4
+- Magento 2.4.4+ (včetně 2.4.9)
+- php 8.1 - 8.5
 - Při problému s použitím modulu nás kontaktujte na emailu: [e-commerce.support@packeta.com](mailto:e-commerce.support@packeta.com)
 
 #### Poskytované funkce:

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     },
     "scripts": {
         "phpcs-compatibility:81": "bash bin/phpcs-compatibility 8.1",
-        "phpcs-compatibility:84": "bash bin/phpcs-compatibility 8.4"
+        "phpcs-compatibility:84": "bash bin/phpcs-compatibility 8.4",
+        "phpcs-compatibility:85": "bash bin/phpcs-compatibility 8.5"
     },
     "config": {
         "allow-plugins": {


### PR DESCRIPTION
[PES-3213](https://packeta.atlassian.net/browse/PES-3213)

Declares support for **PHP 8.1–8.5** and **Magento 2.4.4+ (incl. 2.4.9)** in the README and adds a `phpcs-compatibility:85` check. The module was functionally verified end-to-end on Magento 2.4.9 + PHP 8.5.6 with no PHP 8.5 deprecations or errors.

## Manually verified on Magento 2.4.9 + PHP 8.5.6
- Module load — `di:compile`, carrier feed import, config render
- Checkout pickup-point selection via the real Packeta widget (Z-Point / Z-BOX / Home HD)
- Single packet submission — error path (missing weight → API message) + success path; order-detail Packeta tab (save weight/value/COD)
- Bulk submission via the async consumer `packetery.checkout.packet.submit`
- Label printing — offset modal → PDF
- COD (dobírka) — flag detected, amount stored and sent to the API
- Packet status tracking — cron group `packetery` + consumer start clean; status column renders
- API action log — grid + detail (sanitized request/response)
- Packet cancellation
- Box Manager — full CRUD (create / edit / set-default / delete)
- i18n (CZ frontend carrier labels), ACL (`::box` / `::log` resources enforced)

## PHP 8.5 compatibility
- `phpcs-compatibility:85` passes clean (251 files, 0 issues); verified it does detect 8.5-specific changes
- Manual audit against the PHP 8.5 [deprecated](https://www.php.net/manual/en/migration85.deprecated.php) and [incompatible](https://www.php.net/manual/en/migration85.incompatible.php) change lists → no affected usages (e.g. `SoapClient` used by composition, no `__doRequest()` override; no deprecated funcs/casts/constants)
- No PHP 8.5 deprecations / type errors / fatals in logs during testing

_Out of scope (separate ticket): ACL granularity on some admin controllers (Orders grid, CSV exports, Pricing rules) — documented in a JIRA comment._

[PES-3213]: https://packeta.atlassian.net/browse/PES-3213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ