### PR TITLE
PES-3261: bulk submit feedback and clean API log

### DIFF
--- a/Packetery/Checkout/Controller/Adminhtml/Packet/MassSubmit.php
+++ b/Packetery/Checkout/Controller/Adminhtml/Packet/MassSubmit.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
 namespace Packetery\Checkout\Controller\Adminhtml\Packet;
 
 use Magento\Backend\App\Action;
+use Magento\Framework\Message\MessageInterface;
 use Packetery\Checkout\Logger\BulkPacketSubmitLogger;
 use Packetery\Checkout\Model\Export\ConvertToCsvCustom;
 use Packetery\Checkout\Model\Packet\BulkPacketSubmitPublisher;
+use Packetery\Checkout\Model\Packet\BulkSubmitFeedback;
+use Packetery\Checkout\Model\Packet\BulkSubmitPlanner;
 
 class MassSubmit extends Action
 {
@@ -16,8 +19,14 @@ class MassSubmit extends Action
     /** @var ConvertToCsvCustom */
     private $converter;
 
+    /** @var BulkSubmitPlanner */
+    private $bulkSubmitPlanner;
+
     /** @var BulkPacketSubmitPublisher */
     private $bulkPacketSubmitPublisher;
+
+    /** @var BulkSubmitFeedback */
+    private $bulkSubmitFeedback;
 
     /** @var BulkPacketSubmitLogger */
     private $logger;
@@ -25,12 +34,16 @@ class MassSubmit extends Action
     public function __construct(
         Action\Context $context,
         ConvertToCsvCustom $converter,
+        BulkSubmitPlanner $bulkSubmitPlanner,
         BulkPacketSubmitPublisher $bulkPacketSubmitPublisher,
+        BulkSubmitFeedback $bulkSubmitFeedback,
         BulkPacketSubmitLogger $logger
     ) {
         parent::__construct($context);
         $this->converter = $converter;
+        $this->bulkSubmitPlanner = $bulkSubmitPlanner;
         $this->bulkPacketSubmitPublisher = $bulkPacketSubmitPublisher;
+        $this->bulkSubmitFeedback = $bulkSubmitFeedback;
         $this->logger = $logger;
     }
 
@@ -49,37 +62,45 @@ class MassSubmit extends Action
             return $resultRedirect;
         }
 
-        $publishedCount = 0;
+        $plan = $this->bulkSubmitPlanner->plan(array_map('intval', $orderIds));
+
+        $queuedCount = 0;
         $failedCount = 0;
-        foreach ($orderIds as $orderId) {
+        foreach ($plan->getQueueableOrderIds() as $orderId) {
             try {
-                $this->bulkPacketSubmitPublisher->publish((int) $orderId);
-                $publishedCount++;
+                $this->bulkPacketSubmitPublisher->publish($orderId);
+                $queuedCount++;
             } catch (\Exception $exception) {
                 $failedCount++;
                 $this->logger->error(
                     'Packet mass submit publish failed.',
                     [
-                        'packetery_order_id' => (int) $orderId,
+                        'packetery_order_id' => $orderId,
                         'exception' => $exception,
                     ]
                 );
             }
         }
 
-        if ($publishedCount > 0) {
-            $this->messageManager->addSuccessMessage(
-                __('Submission of %1 packet(s) was queued.', $publishedCount)
-            );
-        }
-
-        if ($failedCount > 0) {
-            $this->messageManager->addErrorMessage(
-                __('%1 packet(s) could not be queued for submission.', $failedCount)
-            );
+        foreach ($this->bulkSubmitFeedback->build($plan, $queuedCount, $failedCount) as $message) {
+            $this->addMessage($message['type'], $message['text']);
         }
 
         return $resultRedirect;
     }
-}
 
+    private function addMessage(string $type, \Magento\Framework\Phrase $text): void
+    {
+        if ($type === MessageInterface::TYPE_SUCCESS) {
+            $this->messageManager->addSuccessMessage($text);
+            return;
+        }
+
+        if ($type === MessageInterface::TYPE_ERROR) {
+            $this->messageManager->addErrorMessage($text);
+            return;
+        }
+
+        $this->messageManager->addNoticeMessage($text);
+    }
+}

--- a/Packetery/Checkout/Model/OrderRepository.php
+++ b/Packetery/Checkout/Model/OrderRepository.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Packetery\Checkout\Model;
+
+class OrderRepository
+{
+    /** @var \Packetery\Checkout\Model\ResourceModel\Order\CollectionFactory */
+    private $orderCollectionFactory;
+
+    public function __construct(
+        \Packetery\Checkout\Model\ResourceModel\Order\CollectionFactory $orderCollectionFactory
+    ) {
+        $this->orderCollectionFactory = $orderCollectionFactory;
+    }
+
+    public function findById(int $orderId): ?Order
+    {
+        $collection = $this->orderCollectionFactory->create();
+        $collection->addFieldToFilter('id', $orderId);
+        $collection->setPageSize(1);
+        $items = $collection->getItems();
+        if ($items === []) {
+            return null;
+        }
+
+        $first = reset($items);
+        if (!$first instanceof Order) {
+            return null;
+        }
+
+        return $first;
+    }
+}

--- a/Packetery/Checkout/Model/Packet/BulkPacketSubmitConsumer.php
+++ b/Packetery/Checkout/Model/Packet/BulkPacketSubmitConsumer.php
@@ -7,12 +7,12 @@ namespace Packetery\Checkout\Model\Packet;
 use Magento\Sales\Model\OrderFactory;
 use Packetery\Checkout\Logger\BulkPacketSubmitLogger;
 use Packetery\Checkout\Model\Order;
-use Packetery\Checkout\Model\ResourceModel\Order\CollectionFactory as PacketeryOrderCollectionFactory;
+use Packetery\Checkout\Model\OrderRepository;
 
 class BulkPacketSubmitConsumer
 {
-    /** @var PacketeryOrderCollectionFactory */
-    private $packeteryOrderCollectionFactory;
+    /** @var OrderRepository */
+    private $orderRepository;
 
     /** @var OrderFactory */
     private $magentoOrderFactory;
@@ -23,21 +23,16 @@ class BulkPacketSubmitConsumer
     /** @var BulkPacketSubmitLogger */
     private $logger;
 
-    /** @var \Packetery\Checkout\Model\Log\LogWriter */
-    private $logWriter;
-
     public function __construct(
-        PacketeryOrderCollectionFactory $packeteryOrderCollectionFactory,
+        OrderRepository $orderRepository,
         OrderFactory $magentoOrderFactory,
         PacketSubmitter $packetSubmitter,
-        BulkPacketSubmitLogger $logger,
-        \Packetery\Checkout\Model\Log\LogWriter $logWriter
+        BulkPacketSubmitLogger $logger
     ) {
-        $this->packeteryOrderCollectionFactory = $packeteryOrderCollectionFactory;
+        $this->orderRepository = $orderRepository;
         $this->magentoOrderFactory = $magentoOrderFactory;
         $this->packetSubmitter = $packetSubmitter;
         $this->logger = $logger;
-        $this->logWriter = $logWriter;
     }
 
     public function process(string $packeteryOrderId): void
@@ -47,7 +42,7 @@ class BulkPacketSubmitConsumer
             return;
         }
 
-        $packeteryOrder = $this->loadPacketeryOrder((int) $packeteryOrderId);
+        $packeteryOrder = $this->orderRepository->findById((int) $packeteryOrderId);
         if (!$packeteryOrder instanceof Order) {
             return;
         }
@@ -59,16 +54,9 @@ class BulkPacketSubmitConsumer
 
         try {
             $this->packetSubmitter->submitPacket($packeteryOrder, $magentoOrder);
+        } catch (\Packetery\Checkout\Model\Api\PacketSubmissionException) {
+            return;
         } catch (\Throwable $exception) {
-            if (!$exception instanceof \Packetery\Checkout\Model\Api\PacketSubmissionException) {
-                $this->logWriter->logError(
-                    \Packetery\Checkout\Model\Log::ACTION_SUBMIT,
-                    $packeteryOrder->getOrderNumber(),
-                    ['orderNumber' => $packeteryOrder->getOrderNumber()],
-                    $exception->getMessage()
-                );
-            }
-
             $this->logger->error(
                 'Bulk shipment submission failed.',
                 [
@@ -78,23 +66,6 @@ class BulkPacketSubmitConsumer
                 ]
             );
         }
-    }
-
-    private function loadPacketeryOrder(int $packeteryOrderId): ?Order
-    {
-        if ($packeteryOrderId <= 0) {
-            return null;
-        }
-
-        $collection = $this->packeteryOrderCollectionFactory->create();
-        $collection->addFilter('id', $packeteryOrderId);
-        $items = $collection->getItems() ?: [];
-        $packeteryOrder = array_shift($items);
-        if (!$packeteryOrder instanceof Order) {
-            return null;
-        }
-
-        return $packeteryOrder;
     }
 }
 

--- a/Packetery/Checkout/Model/Packet/BulkSubmitFeedback.php
+++ b/Packetery/Checkout/Model/Packet/BulkSubmitFeedback.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Packetery\Checkout\Model\Packet;
+
+class BulkSubmitFeedback
+{
+    /**
+     * @return array<int, array{type: string, text: \Magento\Framework\Phrase}>
+     */
+    public function build(BulkSubmitPlan $plan, int $queuedCount, int $failedCount): array
+    {
+        $messages = [];
+
+        if ($queuedCount > 0) {
+            $messages[] = [
+                'type' => \Magento\Framework\Message\MessageInterface::TYPE_SUCCESS,
+                'text' => __('Submission of %1 packet(s) was queued.', $queuedCount),
+            ];
+
+            if ($plan->getMissingConfigCount() > 0) {
+                $messages[] = [
+                    'type' => \Magento\Framework\Message\MessageInterface::TYPE_NOTICE,
+                    'text' => __(
+                        '%1 packet(s) not queued — API password and sender not configured (%2).',
+                        $plan->getMissingConfigCount(),
+                        implode(', ', $plan->getMissingConfigStoreNames())
+                    ),
+                ];
+            }
+        } else {
+            $messages[] = [
+                'type' => \Magento\Framework\Message\MessageInterface::TYPE_NOTICE,
+                'text' => $this->buildNothingQueuedNotice($plan),
+            ];
+        }
+
+        if ($failedCount > 0) {
+            $messages[] = [
+                'type' => \Magento\Framework\Message\MessageInterface::TYPE_ERROR,
+                'text' => __('%1 packet(s) could not be queued for submission.', $failedCount),
+            ];
+        }
+
+        return $messages;
+    }
+
+    private function buildNothingQueuedNotice(BulkSubmitPlan $plan): \Magento\Framework\Phrase
+    {
+        $alreadySubmitted = $plan->getAlreadySubmittedCount();
+        $missingConfig = $plan->getMissingConfigCount();
+        $stores = implode(', ', $plan->getMissingConfigStoreNames());
+
+        if ($alreadySubmitted > 0 && $missingConfig > 0) {
+            return __(
+                'No packets were queued. %1 packet(s) already submitted; API password and sender not configured (%2).',
+                $alreadySubmitted,
+                $stores
+            );
+        }
+
+        if ($alreadySubmitted > 0) {
+            return __('No packets were queued. %1 packet(s) already submitted.', $alreadySubmitted);
+        }
+
+        if ($missingConfig > 0) {
+            return __(
+                'No packets were queued. %1 packet(s) not queued — API password and sender not configured (%2).',
+                $missingConfig,
+                $stores
+            );
+        }
+
+        return __('No packets were queued.');
+    }
+}

--- a/Packetery/Checkout/Model/Packet/BulkSubmitPlan.php
+++ b/Packetery/Checkout/Model/Packet/BulkSubmitPlan.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Packetery\Checkout\Model\Packet;
+
+class BulkSubmitPlan
+{
+    /** @var int[] */
+    private $queueableOrderIds;
+
+    /** @var int */
+    private $alreadySubmittedCount;
+
+    /** @var int */
+    private $missingConfigCount;
+
+    /** @var string[] */
+    private $missingConfigStoreNames;
+
+    /**
+     * @param int[] $queueableOrderIds
+     * @param string[] $missingConfigStoreNames
+     */
+    public function __construct(
+        array $queueableOrderIds,
+        int $alreadySubmittedCount,
+        int $missingConfigCount,
+        array $missingConfigStoreNames
+    ) {
+        $this->queueableOrderIds = $queueableOrderIds;
+        $this->alreadySubmittedCount = $alreadySubmittedCount;
+        $this->missingConfigCount = $missingConfigCount;
+        $this->missingConfigStoreNames = $missingConfigStoreNames;
+    }
+
+    /** @return int[] */
+    public function getQueueableOrderIds(): array
+    {
+        return $this->queueableOrderIds;
+    }
+
+    public function getAlreadySubmittedCount(): int
+    {
+        return $this->alreadySubmittedCount;
+    }
+
+    public function getMissingConfigCount(): int
+    {
+        return $this->missingConfigCount;
+    }
+
+    /** @return string[] */
+    public function getMissingConfigStoreNames(): array
+    {
+        return $this->missingConfigStoreNames;
+    }
+}

--- a/Packetery/Checkout/Model/Packet/BulkSubmitPlanner.php
+++ b/Packetery/Checkout/Model/Packet/BulkSubmitPlanner.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Packetery\Checkout\Model\Packet;
+
+class BulkSubmitPlanner
+{
+    /** @var \Packetery\Checkout\Model\OrderRepository */
+    private $orderRepository;
+
+    /** @var \Magento\Sales\Model\OrderFactory */
+    private $magentoOrderFactory;
+
+    /** @var \Packetery\Checkout\Model\Carrier\Facade */
+    private $carrierFacade;
+
+    /** @var \Magento\Store\Model\StoreManagerInterface */
+    private $storeManager;
+
+    /** @var \Packetery\Checkout\Model\Packet\SubmitPreconditions */
+    private $submitPreconditions;
+
+    public function __construct(
+        \Packetery\Checkout\Model\OrderRepository $orderRepository,
+        \Magento\Sales\Model\OrderFactory $magentoOrderFactory,
+        \Packetery\Checkout\Model\Carrier\Facade $carrierFacade,
+        \Magento\Store\Model\StoreManagerInterface $storeManager,
+        \Packetery\Checkout\Model\Packet\SubmitPreconditions $submitPreconditions
+    ) {
+        $this->orderRepository = $orderRepository;
+        $this->magentoOrderFactory = $magentoOrderFactory;
+        $this->carrierFacade = $carrierFacade;
+        $this->storeManager = $storeManager;
+        $this->submitPreconditions = $submitPreconditions;
+    }
+
+    /**
+     * @param int[] $orderIds
+     */
+    public function plan(array $orderIds): BulkSubmitPlan
+    {
+        $queueableOrderIds = [];
+        $alreadySubmittedCount = 0;
+        $missingConfigCount = 0;
+        $missingConfigStoreNames = [];
+
+        foreach ($orderIds as $orderId) {
+            $orderId = (int) $orderId;
+            $packeteryOrder = $this->orderRepository->findById($orderId);
+            if (!$packeteryOrder instanceof \Packetery\Checkout\Model\Order) {
+                continue;
+            }
+
+            if ($this->submitPreconditions->isAlreadySubmitted($packeteryOrder->getOrderNumber())) {
+                $alreadySubmittedCount++;
+                continue;
+            }
+
+            $magentoOrder = $this->magentoOrderFactory->create()->loadByIncrementId($packeteryOrder->getOrderNumber());
+            if (!$magentoOrder->getId()) {
+                $queueableOrderIds[] = $orderId;
+                continue;
+            }
+
+            $storeId = (int) $magentoOrder->getStoreId();
+            if (!$this->submitPreconditions->hasRequiredConfig($this->carrierFacade->getPacketeryCarrierConfig($storeId))) {
+                $missingConfigCount++;
+                $storeName = $this->resolveStoreName($storeId);
+                if (!in_array($storeName, $missingConfigStoreNames, true)) {
+                    $missingConfigStoreNames[] = $storeName;
+                }
+
+                continue;
+            }
+
+            $queueableOrderIds[] = $orderId;
+        }
+
+        return new BulkSubmitPlan(
+            $queueableOrderIds,
+            $alreadySubmittedCount,
+            $missingConfigCount,
+            $missingConfigStoreNames
+        );
+    }
+
+    private function resolveStoreName(int $storeId): string
+    {
+        try {
+            return (string) $this->storeManager->getStore($storeId)->getName();
+        } catch (\Magento\Framework\Exception\NoSuchEntityException) {
+            return (string) $storeId;
+        }
+    }
+}

--- a/Packetery/Checkout/Model/Packet/PacketSubmitter.php
+++ b/Packetery/Checkout/Model/Packet/PacketSubmitter.php
@@ -13,17 +13,14 @@ class PacketSubmitter
     /** @var \Packetery\Checkout\Model\Api\SoapApiClient */
     private $soapApiClient;
 
-    /** @var \Magento\Framework\App\Config\ScopeConfigInterface */
-    private $scopeConfig;
-
     /** @var \Packetery\Checkout\Model\Weight\Calculator */
     private $weightCalculator;
 
     /** @var \Packetery\Checkout\Model\PacketFactory */
     private $packetFactory;
 
-    /** @var \Packetery\Checkout\Model\ResourceModel\Packet\CollectionFactory */
-    private $packetCollectionFactory;
+    /** @var \Packetery\Checkout\Model\Packet\SubmitPreconditions */
+    private $submitPreconditions;
 
     /** @var \Packetery\Checkout\Model\ResourceModel\Packet */
     private $packetResource;
@@ -51,10 +48,9 @@ class PacketSubmitter
 
     public function __construct(
         \Packetery\Checkout\Model\Api\SoapApiClient $soapApiClient,
-        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
         \Packetery\Checkout\Model\Weight\Calculator $weightCalculator,
         \Packetery\Checkout\Model\PacketFactory $packetFactory,
-        \Packetery\Checkout\Model\ResourceModel\Packet\CollectionFactory $packetCollectionFactory,
+        \Packetery\Checkout\Model\Packet\SubmitPreconditions $submitPreconditions,
         \Packetery\Checkout\Model\ResourceModel\Packet $packetResource,
         \Packetery\Checkout\Model\ResourceModel\Order $orderResource,
         \Packetery\Checkout\Model\Carrier\Facade $carrierFacade,
@@ -65,10 +61,9 @@ class PacketSubmitter
         \Packetery\Checkout\Model\OrderCurrencyResolver $orderCurrencyResolver
     ) {
         $this->soapApiClient = $soapApiClient;
-        $this->scopeConfig = $scopeConfig;
         $this->weightCalculator = $weightCalculator;
         $this->packetFactory = $packetFactory;
-        $this->packetCollectionFactory = $packetCollectionFactory;
+        $this->submitPreconditions = $submitPreconditions;
         $this->packetResource = $packetResource;
         $this->orderResource = $orderResource;
         $this->carrierFacade = $carrierFacade;
@@ -86,19 +81,21 @@ class PacketSubmitter
     public function submitPacket(\Packetery\Checkout\Model\Order $packeteryOrder, \Magento\Sales\Model\Order $magentoOrder): void
     {
         $storeId = (int) $magentoOrder->getStoreId();
-        $apiPassword = (string) ($this->scopeConfig->getValue('carriers/packetery/api_password', \Magento\Store\Model\ScopeInterface::SCOPE_STORE, $storeId) ?? '');
-        $sender = (string) ($this->scopeConfig->getValue('carriers/packetery/sender', \Magento\Store\Model\ScopeInterface::SCOPE_STORE, $storeId) ?? '');
-        if ($apiPassword === '' || $sender === '') {
+        $packeteryConfig = $this->carrierFacade->getPacketeryCarrierConfig($storeId);
+        if ($packeteryConfig === null || !$this->submitPreconditions->hasRequiredConfig($packeteryConfig)) {
             throw new \Packetery\Checkout\Model\Packet\PacketSubmitLocalizedException(
                 __('API password and Sender must be configured.')
             );
         }
 
-        if ($this->isAlreadySubmitted($packeteryOrder->getOrderNumber())) {
+        if ($this->submitPreconditions->isAlreadySubmitted($packeteryOrder->getOrderNumber())) {
             throw new \Packetery\Checkout\Model\Packet\PacketSubmitLocalizedException(
                 __('This packet has already been submitted to Packeta.')
             );
         }
+
+        $apiPassword = (string) $packeteryConfig->getApiPassword();
+        $sender = (string) $packeteryConfig->getSender();
 
         $weight = $this->resolveWeight($packeteryOrder, $magentoOrder);
 
@@ -172,8 +169,7 @@ class PacketSubmitter
         }
 
         $consignPassword = null;
-        $packeteryConfig = $this->carrierFacade->getPacketeryCarrierConfig($storeId);
-        if ($packeteryConfig !== null && $packeteryConfig->isShowConsignPassword()) {
+        if ($packeteryConfig->isShowConsignPassword()) {
             $request = new \Packetery\Checkout\Model\Api\Request\PacketInfoRequest($apiPassword, $createResult->getPacketId());
             $consignPassword = $this->soapApiClient->packetInfo($request)->getConsignPassword();
         }
@@ -246,13 +242,6 @@ class PacketSubmitter
     private function convertToMm(float $cm): int
     {
         return (int) round($this->dimensionsConverter->convert($cm, Unit::CM, Unit::MM));
-    }
-
-    private function isAlreadySubmitted(string $orderNumber): bool
-    {
-        $collection = $this->packetCollectionFactory->create();
-        $collection->addFieldToFilter('order_number', $orderNumber);
-        return $collection->getSize() > 0;
     }
 
     /**

--- a/Packetery/Checkout/Model/Packet/SubmitPreconditions.php
+++ b/Packetery/Checkout/Model/Packet/SubmitPreconditions.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Packetery\Checkout\Model\Packet;
+
+class SubmitPreconditions
+{
+    /** @var \Packetery\Checkout\Model\ResourceModel\Packet\CollectionFactory */
+    private $packetCollectionFactory;
+
+    public function __construct(
+        \Packetery\Checkout\Model\ResourceModel\Packet\CollectionFactory $packetCollectionFactory
+    ) {
+        $this->packetCollectionFactory = $packetCollectionFactory;
+    }
+
+    public function hasRequiredConfig(?\Packetery\Checkout\Model\Carrier\Imp\Packetery\Config $config): bool
+    {
+        return $config !== null && $config->getApiPassword() !== null && $config->getSender() !== null;
+    }
+
+    public function isAlreadySubmitted(string $orderNumber): bool
+    {
+        $collection = $this->packetCollectionFactory->create();
+        $collection->addFieldToFilter('order_number', $orderNumber);
+
+        return $collection->getSize() > 0;
+    }
+}

--- a/Packetery/Checkout/Test/Unit/Model/Packet/BulkPacketSubmitConsumerTest.php
+++ b/Packetery/Checkout/Test/Unit/Model/Packet/BulkPacketSubmitConsumerTest.php
@@ -8,65 +8,46 @@ use Magento\Sales\Model\Order as MagentoOrder;
 use Magento\Sales\Model\OrderFactory;
 use Packetery\Checkout\Logger\BulkPacketSubmitLogger;
 use Packetery\Checkout\Model\Api\PacketSubmissionException;
-use Packetery\Checkout\Model\Log;
-use Packetery\Checkout\Model\Log\LogWriter;
 use Packetery\Checkout\Model\Order;
+use Packetery\Checkout\Model\OrderRepository;
 use Packetery\Checkout\Model\Packet\BulkPacketSubmitConsumer;
 use Packetery\Checkout\Model\Packet\PacketSubmitLocalizedException;
 use Packetery\Checkout\Model\Packet\PacketSubmitter;
-use Packetery\Checkout\Model\ResourceModel\Order\Collection;
-use Packetery\Checkout\Model\ResourceModel\Order\CollectionFactory;
 use Packetery\Checkout\Test\BaseTest;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 #[AllowMockObjectsWithoutExpectations]
 class BulkPacketSubmitConsumerTest extends BaseTest
 {
     private const ORDER_NUMBER = '100000123';
 
-    /**
-     * Pre-flight and unexpected failures are invisible in bulk (no flash message), so the consumer
-     * records a per-shipment grid error to let the merchant find them.
-     */
-    public function testPreflightFailureIsLoggedPerShipment(): void
+    /** @return array<string, array{\Throwable, bool}> */
+    public static function failureProvider(): array
     {
-        $logWriter = $this->createMockWithProps(LogWriter::class);
-        $logWriter->expects($this->once())
-            ->method('logError')
-            ->with(Log::ACTION_SUBMIT, self::ORDER_NUMBER, ['orderNumber' => self::ORDER_NUMBER], 'Already submitted.');
-
-        $this->processWithSubmitException(
-            new PacketSubmitLocalizedException(__('Already submitted.')),
-            $logWriter
-        );
+        return [
+            // Expected guard that slipped past the controller pre-flight (race safeguard) -> file log
+            'guard failure' => [new PacketSubmitLocalizedException(__('Already submitted.')), true],
+            // Genuinely unexpected runtime error -> file log
+            'unexpected error' => [new \RuntimeException('Boom.'), true],
+            // API fault is already recorded in the API log by PacketSubmitter -> not traced again
+            'api fault' => [new PacketSubmissionException('API rejected the packet.'), false],
+        ];
     }
 
     /**
-     * API submission faults are already recorded with full detail by PacketSubmitter, so the
-     * consumer must not create a duplicate grid record for them.
+     * The consumer never writes to the API log: the controller pre-flight handles the expected cases up
+     * front, and API faults are already recorded by PacketSubmitter. Only the guard safeguard and
+     * unexpected errors are traced to the file log; an API fault is left alone (it is already logged).
      */
-    public function testApiSubmissionFaultIsNotLoggedTwice(): void
-    {
-        $logWriter = $this->createMockWithProps(LogWriter::class);
-        $logWriter->expects($this->never())
-            ->method('logError');
-
-        $this->processWithSubmitException(
-            new PacketSubmissionException('API rejected the packet.'),
-            $logWriter
-        );
-    }
-
-    private function processWithSubmitException(\Throwable $submitException, LogWriter $logWriter): void
+    #[DataProvider('failureProvider')]
+    public function testFailureLoggingByType(\Throwable $submitException, bool $expectFileLog): void
     {
         $packeteryOrder = $this->createMockWithProps(Order::class);
         $packeteryOrder->method('getOrderNumber')->willReturn(self::ORDER_NUMBER);
 
-        $collection = $this->createMockWithProps(Collection::class);
-        $collection->method('getItems')->willReturn([$packeteryOrder]);
-
-        $collectionFactory = $this->createStub(CollectionFactory::class);
-        $collectionFactory->method('create')->willReturn($collection);
+        $orderRepository = $this->createStub(OrderRepository::class);
+        $orderRepository->method('findById')->willReturn($packeteryOrder);
 
         $magentoOrder = $this->createMockWithProps(MagentoOrder::class);
         $magentoOrder->method('loadByIncrementId')->willReturn($magentoOrder);
@@ -79,14 +60,13 @@ class BulkPacketSubmitConsumerTest extends BaseTest
         $packetSubmitter->method('submitPacket')->willThrowException($submitException);
 
         $logger = $this->createMockWithProps(BulkPacketSubmitLogger::class);
-        $logger->expects($this->once())->method('error');
+        $logger->expects($expectFileLog ? $this->once() : $this->never())->method('error');
 
         $consumer = new BulkPacketSubmitConsumer(
-            $collectionFactory,
+            $orderRepository,
             $magentoOrderFactory,
             $packetSubmitter,
-            $logger,
-            $logWriter
+            $logger
         );
 
         $consumer->process('5');

--- a/Packetery/Checkout/Test/Unit/Model/Packet/BulkSubmitFeedbackTest.php
+++ b/Packetery/Checkout/Test/Unit/Model/Packet/BulkSubmitFeedbackTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Packetery\Checkout\Test\Unit\Model\Packet;
+
+use Magento\Framework\Message\MessageInterface;
+use Packetery\Checkout\Model\Packet\BulkSubmitFeedback;
+use Packetery\Checkout\Model\Packet\BulkSubmitPlan;
+use Packetery\Checkout\Test\BaseTest;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class BulkSubmitFeedbackTest extends BaseTest
+{
+    /** @return array<string, array{BulkSubmitPlan, int, int, array<int, array{type: string, text: string, args: array<int, mixed>}>}> */
+    public static function feedbackProvider(): array
+    {
+        return [
+            'queued only — already submitted is not mentioned' => [
+                new BulkSubmitPlan([1, 2], 3, 0, []),
+                2,
+                0,
+                [
+                    ['type' => MessageInterface::TYPE_SUCCESS, 'text' => 'Submission of %1 packet(s) was queued.', 'args' => [2]],
+                ],
+            ],
+            'queued plus missing configuration' => [
+                new BulkSubmitPlan([1], 0, 5, ['Store B']),
+                1,
+                0,
+                [
+                    ['type' => MessageInterface::TYPE_SUCCESS, 'text' => 'Submission of %1 packet(s) was queued.', 'args' => [1]],
+                    ['type' => MessageInterface::TYPE_NOTICE, 'text' => '%1 packet(s) not queued — API password and sender not configured (%2).', 'args' => [5, 'Store B']],
+                ],
+            ],
+            'queued plus technical failure' => [
+                new BulkSubmitPlan([1, 2, 3], 0, 0, []),
+                3,
+                2,
+                [
+                    ['type' => MessageInterface::TYPE_SUCCESS, 'text' => 'Submission of %1 packet(s) was queued.', 'args' => [3]],
+                    ['type' => MessageInterface::TYPE_ERROR, 'text' => '%1 packet(s) could not be queued for submission.', 'args' => [2]],
+                ],
+            ],
+            'nothing queued — already submitted only' => [
+                new BulkSubmitPlan([], 3, 0, []),
+                0,
+                0,
+                [
+                    ['type' => MessageInterface::TYPE_NOTICE, 'text' => 'No packets were queued. %1 packet(s) already submitted.', 'args' => [3]],
+                ],
+            ],
+            'nothing queued — missing configuration only' => [
+                new BulkSubmitPlan([], 0, 5, ['Store B', 'Store C']),
+                0,
+                0,
+                [
+                    ['type' => MessageInterface::TYPE_NOTICE, 'text' => 'No packets were queued. %1 packet(s) not queued — API password and sender not configured (%2).', 'args' => [5, 'Store B, Store C']],
+                ],
+            ],
+            'nothing queued — both reasons in a single notice' => [
+                new BulkSubmitPlan([], 3, 2, ['Store B']),
+                0,
+                0,
+                [
+                    ['type' => MessageInterface::TYPE_NOTICE, 'text' => 'No packets were queued. %1 packet(s) already submitted; API password and sender not configured (%2).', 'args' => [3, 'Store B']],
+                ],
+            ],
+            'nothing queued — only technical failures' => [
+                new BulkSubmitPlan([1, 2], 0, 0, []),
+                0,
+                2,
+                [
+                    ['type' => MessageInterface::TYPE_NOTICE, 'text' => 'No packets were queued.', 'args' => []],
+                    ['type' => MessageInterface::TYPE_ERROR, 'text' => '%1 packet(s) could not be queued for submission.', 'args' => [2]],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @param array<int, array{type: string, text: string, args: array<int, mixed>}> $expected
+     */
+    #[DataProvider('feedbackProvider')]
+    public function testBuild(BulkSubmitPlan $plan, int $queuedCount, int $failedCount, array $expected): void
+    {
+        $messages = (new BulkSubmitFeedback())->build($plan, $queuedCount, $failedCount);
+
+        $actual = array_map(
+            static fn(array $message): array => [
+                'type' => $message['type'],
+                'text' => $message['text']->getText(),
+                'args' => $message['text']->getArguments(),
+            ],
+            $messages
+        );
+
+        $this->assertSame($expected, $actual);
+    }
+}

--- a/Packetery/Checkout/Test/Unit/Model/Packet/BulkSubmitPlannerTest.php
+++ b/Packetery/Checkout/Test/Unit/Model/Packet/BulkSubmitPlannerTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Packetery\Checkout\Test\Unit\Model\Packet;
+
+use Magento\Sales\Model\Order as MagentoOrder;
+use Magento\Sales\Model\OrderFactory;
+use Magento\Store\Api\Data\StoreInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use Packetery\Checkout\Model\Carrier\Facade;
+use Packetery\Checkout\Model\Carrier\Imp\Packetery\Config;
+use Packetery\Checkout\Model\Order;
+use Packetery\Checkout\Model\OrderRepository;
+use Packetery\Checkout\Model\Packet\BulkSubmitPlanner;
+use Packetery\Checkout\Model\Packet\SubmitPreconditions;
+use Packetery\Checkout\Test\BaseTest;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+
+#[AllowMockObjectsWithoutExpectations]
+class BulkSubmitPlannerTest extends BaseTest
+{
+    public function testPlanGroupsOrdersByExpectedOutcome(): void
+    {
+        $orderNumbersById = [
+            1 => '0001',
+            2 => '0002',
+            3 => '0003',
+            4 => '0004',
+            5 => '0005',
+        ];
+        $storeByNumber = [
+            '0001' => 1,
+            '0002' => 2,
+            '0003' => 2,
+            '0004' => 3,
+            '0005' => 2,
+        ];
+        $configuredConfig = $this->createStub(Config::class);
+
+        $planner = new BulkSubmitPlanner(
+            $this->createOrderRepository($orderNumbersById),
+            $this->createMagentoOrderFactory($storeByNumber),
+            $this->createCarrierFacade([1], $configuredConfig),
+            $this->createStoreManager([2 => 'Store Two', 3 => 'Store Three']),
+            $this->createSubmitPreconditions(['0002'], $configuredConfig)
+        );
+
+        $plan = $planner->plan([1, 2, 3, 4, 5, 99]);
+
+        $this->assertSame([1], $plan->getQueueableOrderIds());
+        $this->assertSame(1, $plan->getAlreadySubmittedCount());
+        $this->assertSame(3, $plan->getMissingConfigCount());
+        $this->assertSame(['Store Two', 'Store Three'], $plan->getMissingConfigStoreNames());
+    }
+
+    /**
+     * @param array<int, string> $orderNumbersById
+     */
+    private function createOrderRepository(array $orderNumbersById): OrderRepository
+    {
+        $orderRepository = $this->createStub(OrderRepository::class);
+        $orderRepository->method('findById')->willReturnCallback(
+            function (int $orderId) use ($orderNumbersById): ?Order {
+                if (!isset($orderNumbersById[$orderId])) {
+                    return null;
+                }
+
+                $order = $this->createMockWithProps(Order::class);
+                $order->method('getOrderNumber')->willReturn($orderNumbersById[$orderId]);
+
+                return $order;
+            }
+        );
+
+        return $orderRepository;
+    }
+
+    /**
+     * @param array<string, int> $storeByNumber
+     */
+    private function createMagentoOrderFactory(array $storeByNumber): OrderFactory
+    {
+        $factory = $this->createStub(OrderFactory::class);
+        $factory->method('create')->willReturnCallback(
+            function () use ($storeByNumber): MagentoOrder {
+                $captured = new \stdClass();
+                $captured->number = '';
+
+                $order = $this->createMockWithProps(MagentoOrder::class);
+                $order->method('loadByIncrementId')->willReturnCallback(
+                    function ($number) use ($captured, $order) {
+                        $captured->number = (string) $number;
+
+                        return $order;
+                    }
+                );
+                $order->method('getId')->willReturnCallback(
+                    fn() => isset($storeByNumber[$captured->number]) ? 5 : 0
+                );
+                $order->method('getStoreId')->willReturnCallback(
+                    fn() => $storeByNumber[$captured->number] ?? 0
+                );
+
+                return $order;
+            }
+        );
+
+        return $factory;
+    }
+
+    /**
+     * @param int[] $configuredStoreIds
+     */
+    private function createCarrierFacade(array $configuredStoreIds, Config $configuredConfig): Facade
+    {
+        $facade = $this->createStub(Facade::class);
+        $facade->method('getPacketeryCarrierConfig')->willReturnCallback(
+            fn(int $storeId): ?Config => in_array($storeId, $configuredStoreIds, true) ? $configuredConfig : null
+        );
+
+        return $facade;
+    }
+
+    /**
+     * @param array<int, string> $storeNamesById
+     */
+    private function createStoreManager(array $storeNamesById): StoreManagerInterface
+    {
+        $storeManager = $this->createStub(StoreManagerInterface::class);
+        $storeManager->method('getStore')->willReturnCallback(
+            function ($storeId) use ($storeNamesById): StoreInterface {
+                $store = $this->createStub(StoreInterface::class);
+                $store->method('getName')->willReturn($storeNamesById[(int) $storeId] ?? (string) $storeId);
+
+                return $store;
+            }
+        );
+
+        return $storeManager;
+    }
+
+    /**
+     * @param string[] $submittedOrderNumbers
+     */
+    private function createSubmitPreconditions(array $submittedOrderNumbers, Config $configuredConfig): SubmitPreconditions
+    {
+        $preconditions = $this->createStub(SubmitPreconditions::class);
+        $preconditions->method('isAlreadySubmitted')->willReturnCallback(
+            fn(string $orderNumber): bool => in_array($orderNumber, $submittedOrderNumbers, true)
+        );
+        $preconditions->method('hasRequiredConfig')->willReturnCallback(
+            fn(?Config $config): bool => $config === $configuredConfig
+        );
+
+        return $preconditions;
+    }
+}

--- a/Packetery/Checkout/Test/Unit/Model/Packet/PacketSubmitterTest.php
+++ b/Packetery/Checkout/Test/Unit/Model/Packet/PacketSubmitterTest.php
@@ -12,11 +12,10 @@ use Packetery\Checkout\Model\Carrier\Imp\Packetery\Config;
 use Packetery\Checkout\Model\OrderCurrencyResolver;
 use Packetery\Checkout\Model\Packet\PacketAttributes;
 use Packetery\Checkout\Model\Packet\PacketSubmitter;
+use Packetery\Checkout\Model\Packet\SubmitPreconditions;
 use Packetery\Checkout\Model\PacketFactory;
 use Packetery\Checkout\Model\ResourceModel\Order as OrderResource;
 use Packetery\Checkout\Model\ResourceModel\Packet as PacketResource;
-use Packetery\Checkout\Model\ResourceModel\Packet\Collection as PacketCollection;
-use Packetery\Checkout\Model\ResourceModel\Packet\CollectionFactory as PacketCollectionFactory;
 use Packetery\Checkout\Model\Weight\Calculator;
 use Packetery\Checkout\Test\BaseTest;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
@@ -478,19 +477,17 @@ class PacketSubmitterTest extends BaseTest
         ?object $packet = null,
         bool $showConsignPassword = false
     ): PacketSubmitter {
-        $scopeConfig = $this->createStub(\Magento\Framework\App\Config\ScopeConfigInterface::class);
-        $scopeConfig->method('getValue')->willReturn('configured');
-
-        $packetCollection = $this->createStub(PacketCollection::class);
-        $packetCollection->method('getSize')->willReturn(0);
-        $packetCollectionFactory = $this->createStub(PacketCollectionFactory::class);
-        $packetCollectionFactory->method('create')->willReturn($packetCollection);
+        $submitPreconditions = $this->createStub(SubmitPreconditions::class);
+        $submitPreconditions->method('hasRequiredConfig')->willReturn(true);
+        $submitPreconditions->method('isAlreadySubmitted')->willReturn(false);
 
         $packetFactory = $this->createStub(PacketFactory::class);
         $packetFactory->method('create')->willReturn($packet ?? $this->createStub(\Packetery\Checkout\Model\Packet::class));
 
         $config = $this->createStub(Config::class);
         $config->method('isShowConsignPassword')->willReturn($showConsignPassword);
+        $config->method('getApiPassword')->willReturn('configured');
+        $config->method('getSender')->willReturn('configured');
         $facade = $this->createStub(Facade::class);
         $facade->method('getPacketeryCarrierConfig')->willReturn($config);
 
@@ -508,10 +505,9 @@ class PacketSubmitterTest extends BaseTest
             PacketSubmitter::class,
             [
                 'soapApiClient' => $soapApiClient,
-                'scopeConfig' => $scopeConfig,
                 'weightCalculator' => $this->createStub(Calculator::class),
                 'packetFactory' => $packetFactory,
-                'packetCollectionFactory' => $packetCollectionFactory,
+                'submitPreconditions' => $submitPreconditions,
                 'packetResource' => $this->createStub(PacketResource::class),
                 'orderResource' => $orderResource,
                 'carrierFacade' => $facade,

--- a/Packetery/Checkout/Test/Unit/Model/Packet/SubmitPreconditionsTest.php
+++ b/Packetery/Checkout/Test/Unit/Model/Packet/SubmitPreconditionsTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Packetery\Checkout\Test\Unit\Model\Packet;
+
+use Packetery\Checkout\Model\Carrier\Imp\Packetery\Config;
+use Packetery\Checkout\Model\Packet\SubmitPreconditions;
+use Packetery\Checkout\Model\ResourceModel\Packet\Collection;
+use Packetery\Checkout\Model\ResourceModel\Packet\CollectionFactory;
+use Packetery\Checkout\Test\BaseTest;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+#[AllowMockObjectsWithoutExpectations]
+class SubmitPreconditionsTest extends BaseTest
+{
+    /** @return array<string, array{?string, ?string, bool}> */
+    public static function configProvider(): array
+    {
+        return [
+            'api password and sender set' => ['apiPassword', 'sender', true],
+            'api password missing' => [null, 'sender', false],
+            'sender missing' => ['apiPassword', null, false],
+            'both missing' => [null, null, false],
+        ];
+    }
+
+    #[DataProvider('configProvider')]
+    public function testHasRequiredConfig(?string $apiPassword, ?string $sender, bool $expected): void
+    {
+        $config = $this->createStub(Config::class);
+        $config->method('getApiPassword')->willReturn($apiPassword);
+        $config->method('getSender')->willReturn($sender);
+
+        $this->assertSame($expected, $this->createPreconditions()->hasRequiredConfig($config));
+    }
+
+    public function testHasRequiredConfigIsFalseWhenCarrierNotConfigured(): void
+    {
+        $this->assertFalse($this->createPreconditions()->hasRequiredConfig(null));
+    }
+
+    /** @return array<string, array{int, bool}> */
+    public static function alreadySubmittedProvider(): array
+    {
+        return [
+            'packet exists' => [1, true],
+            'no packet' => [0, false],
+        ];
+    }
+
+    #[DataProvider('alreadySubmittedProvider')]
+    public function testIsAlreadySubmitted(int $size, bool $expected): void
+    {
+        $collection = $this->createMockWithProps(Collection::class);
+        $collection->method('getSize')->willReturn($size);
+
+        $collectionFactory = $this->createStub(CollectionFactory::class);
+        $collectionFactory->method('create')->willReturn($collection);
+
+        $this->assertSame($expected, (new SubmitPreconditions($collectionFactory))->isAlreadySubmitted('000000001'));
+    }
+
+    private function createPreconditions(): SubmitPreconditions
+    {
+        return new SubmitPreconditions($this->createStub(CollectionFactory::class));
+    }
+}

--- a/Packetery/Checkout/i18n/cs_CZ.csv
+++ b/Packetery/Checkout/i18n/cs_CZ.csv
@@ -281,3 +281,8 @@
 "Packet value","Hodnota zásilky"
 "Packeta – packet","Packeta – zásilka"
 "Pick-up point","Výdejní místo"
+"No packets were queued.","Do fronty nebyly zařazeny žádné zásilky."
+"No packets were queued. %1 packet(s) already submitted.","Do fronty nebyly zařazeny žádné zásilky. %1 zásilek již bylo podáno."
+"No packets were queued. %1 packet(s) not queued — API password and sender not configured (%2).","Do fronty nebyly zařazeny žádné zásilky. %1 zásilek nebylo zařazeno — API heslo a odesílatel nejsou vyplněni (%2)."
+"No packets were queued. %1 packet(s) already submitted; API password and sender not configured (%2).","Do fronty nebyly zařazeny žádné zásilky. %1 zásilek již bylo podáno; API heslo a odesílatel nejsou vyplněni (%2)."
+"%1 packet(s) not queued — API password and sender not configured (%2).","%1 zásilek nebylo zařazeno — API heslo a odesílatel nejsou vyplněni (%2)."

--- a/Packetery/Checkout/i18n/en_GB.csv
+++ b/Packetery/Checkout/i18n/en_GB.csv
@@ -281,3 +281,8 @@
 "Packet value","Packet value"
 "Packeta – packet","Packeta – packet"
 "Pick-up point","Pick-up point"
+"No packets were queued.","No packets were queued."
+"No packets were queued. %1 packet(s) already submitted.","No packets were queued. %1 packet(s) already submitted."
+"No packets were queued. %1 packet(s) not queued — API password and sender not configured (%2).","No packets were queued. %1 packet(s) not queued — API password and sender not configured (%2)."
+"No packets were queued. %1 packet(s) already submitted; API password and sender not configured (%2).","No packets were queued. %1 packet(s) already submitted; API password and sender not configured (%2)."
+"%1 packet(s) not queued — API password and sender not configured (%2).","%1 packet(s) not queued — API password and sender not configured (%2)."

--- a/Packetery/Checkout/i18n/sk_SK.csv
+++ b/Packetery/Checkout/i18n/sk_SK.csv
@@ -281,3 +281,8 @@
 "Packet value","Hodnota zásielky"
 "Packeta – packet","Packeta – zásielka"
 "Pick-up point","Výdajné miesto"
+"No packets were queued.","Do fronty neboli zaradené žiadne zásielky."
+"No packets were queued. %1 packet(s) already submitted.","Do fronty neboli zaradené žiadne zásielky. %1 zásielok už bolo podaných."
+"No packets were queued. %1 packet(s) not queued — API password and sender not configured (%2).","Do fronty neboli zaradené žiadne zásielky. %1 zásielok nebolo zaradených — API heslo a odosielateľ nie sú vyplnené (%2)."
+"No packets were queued. %1 packet(s) already submitted; API password and sender not configured (%2).","Do fronty neboli zaradené žiadne zásielky. %1 zásielok už bolo podaných; API heslo a odosielateľ nie sú vyplnené (%2)."
+"%1 packet(s) not queued — API password and sender not configured (%2).","%1 zásielok nebolo zaradených — API heslo a odosielateľ nie sú vyplnené (%2)."


### PR DESCRIPTION
[PES-3261](https://packeta.atlassian.net/browse/PES-3261)

Bulk packet submission now skips already-submitted orders and orders missing per-store configuration instead of logging them as API errors, and shows the merchant a per-result summary. Expected cases no longer pollute the API log — only API faults are recorded there, everything else goes to the file log.


[PES-3261]: https://packeta.atlassian.net/browse/PES-3261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ