### PR TITLE
PES-3263: Remove bullet from API log status column

### DIFF
--- a/Packetery/Checkout/view/adminhtml/web/template/grid/cells/log-status.html
+++ b/Packetery/Checkout/view/adminhtml/web/template/grid/cells/log-status.html
@@ -1,3 +1,3 @@
 <span class="packetery-log-status" data-bind="css: $row()[$col.index] === 'error' ? 'packetery-log-status-error' : 'packetery-log-status-success'">
-    &#9679; <span data-bind="text: $col.getLabel($row())"></span>
+    <span data-bind="text: $col.getLabel($row())"></span>
 </span>


### PR DESCRIPTION
[PES-3263](https://packeta.atlassian.net/browse/PES-3263)

Removes the redundant bullet from the API action log status column so the status shows as colored text only (Error red, Success green).

[PES-3263]: https://packeta.atlassian.net/browse/PES-3263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ