### PR TITLE
PES-3280: harden admin CSV export and print template output

### DIFF
--- a/Packetery/Checkout/Block/Adminhtml/Order/GridExport.php
+++ b/Packetery/Checkout/Block/Adminhtml/Order/GridExport.php
@@ -55,12 +55,6 @@ class GridExport extends \Magento\Backend\Block\Widget\Grid\Extended
         return parent::_prepareCollection();
     }
 
-
-    public function massaction(array $items, $action, $acceptAlert = false, $massActionSelection = '')
-    {
-        die;
-    }
-
     /**
      * @param string $orderIds
      * @return string|null

--- a/Packetery/Checkout/Controller/Adminhtml/Order/ExportMass.php
+++ b/Packetery/Checkout/Controller/Adminhtml/Order/ExportMass.php
@@ -20,6 +20,9 @@ class ExportMass extends \Magento\Backend\App\Action
     /** @var ConvertToCsvCustom */
     private $converter;
 
+    /** @var \Magento\Framework\App\Response\Http\FileFactory */
+    private $fileFactory;
+
     /**
      * ExportMass constructor.
      *
@@ -34,7 +37,8 @@ class ExportMass extends \Magento\Backend\App\Action
         \Magento\Framework\View\Result\PageFactory $resultPageFactory,
         \Packetery\Checkout\Helper\Data $data,
         \Packetery\Checkout\Model\ResourceModel\Order\CollectionFactory $orderCollectionFactory,
-        ConvertToCsvCustom $converter
+        ConvertToCsvCustom $converter,
+        \Magento\Framework\App\Response\Http\FileFactory $fileFactory
     ) {
         parent::__construct($context);
 
@@ -42,6 +46,7 @@ class ExportMass extends \Magento\Backend\App\Action
         $this->data = $data;
         $this->orderCollectionFactory = $orderCollectionFactory;
         $this->converter = $converter;
+        $this->fileFactory = $fileFactory;
     }
 
     /**
@@ -85,24 +90,10 @@ class ExportMass extends \Magento\Backend\App\Action
         );
         $collection->save();
 
-        $this->_sendUploadResponse($this->data->getExportFileName(), $content);
-    }
-
-    /**
-     * @param string $fileName
-     * @param string|null $content
-     * @param string $contentType
-     */
-    protected function _sendUploadResponse(string $fileName, ?string $content, string $contentType = 'application/octet-stream') {
-        $this->_response->setHttpResponseCode(200)
-            ->setHeader('Pragma', 'public', true)
-            ->setHeader('Cache-Control', 'must-revalidate, post-check=0, pre-check=0', true)
-            ->setHeader('Content-type', $contentType, true)
-            ->setHeader('Content-Length', strlen($content), true)
-            ->setHeader('Content-Disposition', 'attachment; filename="' . $fileName . '"', true)
-            ->setHeader('Last-Modified', date('r'), true)
-            ->setBody($content)
-            ->sendResponse();
-        die;
+        return $this->fileFactory->create(
+            $this->data->getExportFileName(),
+            $content,
+            \Magento\Framework\App\Filesystem\DirectoryList::VAR_DIR
+        );
     }
 }

--- a/Packetery/Checkout/Controller/Adminhtml/Order/ExportPacketeryCsv.php
+++ b/Packetery/Checkout/Controller/Adminhtml/Order/ExportPacketeryCsv.php
@@ -22,13 +22,15 @@ class ExportPacketeryCsv extends \Magento\Backend\App\Action
         \Magento\Backend\App\Action\Context  $context,
         \Magento\Framework\View\Result\PageFactory $resultPageFactory,
         \Packetery\Checkout\Helper\Data $data,
-        \Packetery\Checkout\Model\ResourceModel\Order\CollectionFactory $orderCollectionFactory
+        \Packetery\Checkout\Model\ResourceModel\Order\CollectionFactory $orderCollectionFactory,
+        \Magento\Framework\App\Response\Http\FileFactory $fileFactory
     ) {
         parent::__construct($context);
 
         $this->resultPageFactory  = $resultPageFactory;
         $this->data = $data;
         $this->orderCollectionFactory = $orderCollectionFactory;
+        $this->_fileFactory = $fileFactory;
     }
     public function execute()
     {
@@ -57,21 +59,10 @@ class ExportPacketeryCsv extends \Magento\Backend\App\Action
         );
         $collection->save();
 
-        $this->_sendUploadResponse($this->data->getExportFileName(), $content);
-
-    }
-
-    protected function _sendUploadResponse($fileName, $content, $contentType='application/octet-stream')
-    {
-        $this->_response->setHttpResponseCode(200)
-            ->setHeader('Pragma', 'public', true)
-            ->setHeader('Cache-Control', 'must-revalidate, post-check=0, pre-check=0', true)
-            ->setHeader('Content-type', $contentType, true)
-            ->setHeader('Content-Length', strlen($content), true)
-            ->setHeader('Content-Disposition', 'attachment; filename="' . $fileName . '"', true)
-            ->setHeader('Last-Modified', date('r'), true)
-            ->setBody($content)
-            ->sendResponse();
-        die;
+        return $this->_fileFactory->create(
+            $this->data->getExportFileName(),
+            $content,
+            \Magento\Framework\App\Filesystem\DirectoryList::VAR_DIR
+        );
     }
 }

--- a/Packetery/Checkout/Controller/Adminhtml/Order/ExportPacketeryCsvAll.php
+++ b/Packetery/Checkout/Controller/Adminhtml/Order/ExportPacketeryCsvAll.php
@@ -22,13 +22,15 @@ class ExportPacketeryCsvAll extends \Magento\Backend\App\Action
         \Magento\Backend\App\Action\Context  $context,
         \Magento\Framework\View\Result\PageFactory $resultPageFactory,
         \Packetery\Checkout\Helper\Data $data,
-        \Packetery\Checkout\Model\ResourceModel\Order\CollectionFactory $orderCollectionFactory
+        \Packetery\Checkout\Model\ResourceModel\Order\CollectionFactory $orderCollectionFactory,
+        \Magento\Framework\App\Response\Http\FileFactory $fileFactory
     ) {
         parent::__construct($context);
 
         $this->resultPageFactory  = $resultPageFactory;
         $this->data = $data;
         $this->orderCollectionFactory = $orderCollectionFactory;
+        $this->_fileFactory = $fileFactory;
     }
 
     public function execute()
@@ -56,21 +58,10 @@ class ExportPacketeryCsvAll extends \Magento\Backend\App\Action
         );
         $collection->save();
 
-        $this->_sendUploadResponse($this->data->getExportFileName(), $content);
-
-    }
-
-    protected function _sendUploadResponse($fileName, $content, $contentType='application/octet-stream')
-    {
-        $this->_response->setHttpResponseCode(200)
-            ->setHeader('Pragma', 'public', true)
-            ->setHeader('Cache-Control', 'must-revalidate, post-check=0, pre-check=0', true)
-            ->setHeader('Content-type', $contentType, true)
-            ->setHeader('Content-Length', strlen($content), true)
-            ->setHeader('Content-Disposition', 'attachment; filename="' . $fileName . '"', true)
-            ->setHeader('Last-Modified', date('r'), true)
-            ->setBody($content)
-            ->sendResponse();
-        die;
+        return $this->_fileFactory->create(
+            $this->data->getExportFileName(),
+            $content,
+            \Magento\Framework\App\Filesystem\DirectoryList::VAR_DIR
+        );
     }
 }

--- a/Packetery/Checkout/Model/Label/LabelFormats.php
+++ b/Packetery/Checkout/Model/Label/LabelFormats.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Packetery\Checkout\Model\Label;
 
-final class LabelFormats
+class LabelFormats
 {
     public const DEFAULT_FORMAT = 'A6 on A4';
 

--- a/Packetery/Checkout/view/adminhtml/templates/order_collection_print_dispatcher.phtml
+++ b/Packetery/Checkout/view/adminhtml/templates/order_collection_print_dispatcher.phtml
@@ -4,14 +4,17 @@
     <meta charset="utf-8"/>
 </head>
 <body>
-<p id="packetery-order-collection-fallback" style="display:none;">
-    <?= __('Your browser blocked the popup.') ?>
-    <a id="packetery-order-collection-fallback-link" href="#" target="_blank"><?= __('Open packet list') ?></a>
+<p id="packetery-order-collection-fallback" style="display:none;"
+   data-payload="<?= $block->escapeHtmlAttr($block->getData('payload_json')) ?>"
+   data-listing-url="<?= $block->escapeHtmlAttr($block->getData('listing_url_json')) ?>">
+    <?= $block->escapeHtml(__('Your browser blocked the popup.')) ?>
+    <a id="packetery-order-collection-fallback-link" href="#" target="_blank"><?= $block->escapeHtml(__('Open packet list')) ?></a>
 </p>
 <script>
 (function () {
-    var data = <?= $block->getData('payload_json') ?>;
-    var listingUrl = <?= $block->getData('listing_url_json') ?>;
+    var dataEl = document.getElementById('packetery-order-collection-fallback');
+    var data = JSON.parse(dataEl.getAttribute('data-payload'));
+    var listingUrl = JSON.parse(dataEl.getAttribute('data-listing-url'));
     var fallbackWrapper = document.getElementById('packetery-order-collection-fallback');
     var fallbackLink = document.getElementById('packetery-order-collection-fallback-link');
     var binaryString = atob(data.html_b64);

--- a/Packetery/Checkout/view/adminhtml/templates/packet/mass_print_result.phtml
+++ b/Packetery/Checkout/view/adminhtml/templates/packet/mass_print_result.phtml
@@ -4,14 +4,17 @@
     <meta charset="utf-8"/>
 </head>
 <body>
-<p id="packetery-mass-print-fallback" style="display:none;">
-    <?= __('If you are not redirected automatically,') ?>
-    <a id="packetery-mass-print-fallback-link" href="#"><?= __('click here') ?></a>.
+<p id="packetery-mass-print-fallback" style="display:none;"
+   data-payload="<?= $block->escapeHtmlAttr($block->getData('payload_json')) ?>"
+   data-listing-url="<?= $block->escapeHtmlAttr($block->getData('listing_url_json')) ?>">
+    <?= $block->escapeHtml(__('If you are not redirected automatically,')) ?>
+    <a id="packetery-mass-print-fallback-link" href="#"><?= $block->escapeHtml(__('click here')) ?></a>.
 </p>
 <script>
 (function () {
-    var data = <?= $block->getData('payload_json') ?>;
-    var listingUrl = <?= $block->getData('listing_url_json') ?>;
+    var dataEl = document.getElementById('packetery-mass-print-fallback');
+    var data = JSON.parse(dataEl.getAttribute('data-payload'));
+    var listingUrl = JSON.parse(dataEl.getAttribute('data-listing-url'));
     var fallbackWrapper = document.getElementById('packetery-mass-print-fallback');
     var fallbackLink = document.getElementById('packetery-mass-print-fallback-link');
 


### PR DESCRIPTION
- ošetřený (escaped) výstup v adminních tiskových šablonách
- CSV se stahuje přes FileFactory místo raw `die()`
- odstraněn zakázaný `final` modifier a mrtvá `die()` metoda