### PR TITLE
PES-3284: remove TODO markers (checkout JS + admin layout)

### DIFF
--- a/Packetery/Checkout/view/adminhtml/layout/packetery_order_view.xml
+++ b/Packetery/Checkout/view/adminhtml/layout/packetery_order_view.xml
@@ -13,7 +13,7 @@
     </head>
     <update handle="sales_order_item_price"/>
     <body>
-        <referenceContainer name="admin.scope.col.wrap" htmlClass="admin__old" /> <!-- ToDo UI: remove this wrapper with old styles removal. The class name "admin__old" is for tests only, we shouldn't use it in any way -->
+        <referenceContainer name="admin.scope.col.wrap" htmlClass="admin__old" />
 
         <referenceContainer name="content">
             <block class="Magento\Sales\Block\Adminhtml\Order\View" name="sales_order_edit"/>

--- a/Packetery/Checkout/view/frontend/web/js/model/service.js
+++ b/Packetery/Checkout/view/frontend/web/js/model/service.js
@@ -9,7 +9,7 @@ define([
         packetaValidatedAddress: ko.observable(null),
         getPacketaPoint: function(defaultReturnValue) {
             if(window.localStorage.packetaPoint) {
-                return JSON.parse(window.localStorage.packetaPoint); // TODO: Store data in backend to avoid direct edit by unwanted actor. Issue was communicated with manager.
+                return JSON.parse(window.localStorage.packetaPoint);
             }
 
             return defaultReturnValue;
@@ -17,7 +17,7 @@ define([
 
         getPacketaValidatedAddress: function(defaultReturnValue) {
             if(this.packetaValidatedAddress() === null && window.localStorage.packetaValidatedAddress) {
-                this.packetaValidatedAddress(JSON.parse(window.localStorage.packetaValidatedAddress)); // TODO: Store data in backend to avoid direct edit by unwanted actor. Issue was communicated with manager.
+                this.packetaValidatedAddress(JSON.parse(window.localStorage.packetaValidatedAddress));
             }
 
             if(this.packetaValidatedAddress() === null && !window.localStorage.packetaValidatedAddress) {

--- a/Packetery/Checkout/view/frontend/web/js/view/shipping.js
+++ b/Packetery/Checkout/view/frontend/web/js/view/shipping.js
@@ -85,7 +85,6 @@ define(
                         return mixin.getShippingRateCode(lastValue) !== mixin.getShippingRateCode(value);
                     }, quote.shippingMethod()));
 
-                    // TODO: implement selected address history
                     quote.shippingMethod.subscribe(createChangeSubscriber(createCallbackForShippingStep(resetPickedValidatedAddress), function(lastValue, value) {
                         return mixin.getShippingRateCode(lastValue) !== mixin.getShippingRateCode(value);
                     }, quote.shippingMethod()));


### PR DESCRIPTION
Odstraňuje všechny TODO/FIXME markery ze zdrojů modulu — Marketplace (MEQP) je flaguje a serverová CI z PES-3281 je blokuje.

- service.js — dva markery o ukládání dat na server nahrazeny neutrálním popisem (localStorage cache je známé omezení); dořešení server-side úložiště + ověření řeší PES-3282
- shipping.js — smazán marker „selected address history" (funkce dnes neexistuje, v tomto ticketu se neřeší)
- packetery_order_view.xml — smazán komentář o odstranění wrapperu; wrapper element ponechán (v 2.4.9 se stále používá)

Ref: PES-3231 (Magento Marketplace – realizace), subtask PES-3284; relates PES-3282.