### PR TITLE
PES-3294: local marketplace checks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,6 @@
 .gitattributes export-ignore
 .gitignore export-ignore
+
+# Shell helpers must keep LF even on Windows checkouts (core.autocrlf), otherwise the
+# trailing CR ends up in the arguments and the composer scripts fail to find the paths.
+bin/* text eol=lf

--- a/.github/workflows/marketplace-checks.yml
+++ b/.github/workflows/marketplace-checks.yml
@@ -83,7 +83,7 @@ jobs:
 
             -   name: Copy-paste detector (advisory)
                 continue-on-error: true
-                run: .mp-tools/vendor/bin/phpcpd --exclude Test Packetery/Checkout
+                run: .mp-tools/vendor/bin/phpcpd --exclude Packetery/Checkout/Test Packetery/Checkout
 
     php-lint:
         runs-on: ubuntu-24.04

--- a/.github/workflows/marketplace-checks.yml
+++ b/.github/workflows/marketplace-checks.yml
@@ -85,6 +85,51 @@ jobs:
                 continue-on-error: true
                 run: .mp-tools/vendor/bin/phpcpd --exclude Packetery/Checkout/Test Packetery/Checkout
 
+    copy-paste-vs-core:
+        runs-on: ubuntu-24.04
+        timeout-minutes: 10
+        # Advisory for now: findings are reported and assessed by hand.
+        # It turns blocking once we know they are not false positives.
+        continue-on-error: true
+        env:
+            MAGENTO_CORE_VERSION: '2.4.9'
+        steps:
+            -   uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+            -   uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+                with:
+                    php-version: '8.4'
+                    tools: composer
+                    coverage: none
+
+            -   name: Install the marketplace tools
+                # --no-dev: the job runs phpcpd from tools/, the root dev tools are only dead weight here.
+                run: composer install --no-dev --no-interaction --no-progress
+
+            -   name: Restore the Magento core checkout
+                id: core-cache
+                uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+                with:
+                    path: magento-core
+                    key: magento-core-${{ env.MAGENTO_CORE_VERSION }}-${{ hashFiles('.github/workflows/marketplace-checks.yml') }}
+
+            -   name: Clone the Magento core
+                if: steps.core-cache.outputs.cache-hit != 'true'
+                # Sparse checkout of the two source trees, then only the php files are kept:
+                # 364 MB of clone shrinks to 112 MB of cache and phpcpd reads nothing else.
+                run: |
+                    git clone --depth 1 --branch "$MAGENTO_CORE_VERSION" --filter=blob:none --sparse \
+                        https://github.com/magento/magento2.git magento-core
+                    git -C magento-core sparse-checkout set app/code/Magento lib/internal/Magento
+                    rm -rf magento-core/.git
+                    find magento-core -type f ! -name '*.php' -delete
+
+            -   name: Copy-paste detector against core
+                run: |
+                    bash bin/phpcpd-core \
+                        magento-core/app/code/Magento \
+                        magento-core/lib/internal/Magento
+
     php-lint:
         runs-on: ubuntu-24.04
         timeout-minutes: 10

--- a/.github/workflows/marketplace-checks.yml
+++ b/.github/workflows/marketplace-checks.yml
@@ -28,6 +28,9 @@ jobs:
             -   name: Validate package manifest
                 run: composer validate Packetery/Checkout/composer.json
 
+            -   name: Verify the manifest against the Marketplace rules
+                run: php bin/verify-manifest
+
             -   name: Verify composer.json and CHANGE_LOG.txt versions agree
                 run: |
                     MANIFEST=$(php -r 'echo json_decode(file_get_contents("Packetery/Checkout/composer.json"))->version;')
@@ -136,6 +139,8 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
+                # source of truth for the PHP versions we claim to support, bin/verify-manifest
+                # compares the manifest constraint against it
                 php-version: ['8.1', '8.2', '8.3', '8.4', '8.5']
         steps:
             -   uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/marketplace-checks.yml
+++ b/.github/workflows/marketplace-checks.yml
@@ -118,7 +118,9 @@ jobs:
                     coverage: none
 
             -   name: Install dev tooling
-                run: composer install --no-interaction --no-progress
+                # --no-scripts: this job only needs the root PHPCompatibility ruleset, not the
+                # marketplace tools that the root post-install hook would pull into tools/.
+                run: composer install --no-interaction --no-progress --no-scripts
 
             -   name: PHPCompatibility 8.1 to 8.5
                 run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.idea
 /vendor
+/tools/vendor

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Price rules are created as unavailable, without set maximum weight.
 
 The module includes PHPCompatibility checks to ensure compatibility with PHP 8.1 through PHP 8.5.
 
-Requirements to run the checks: PHP 8.4 and Composer 2.8.6. From the module directory (where `composer.json` lives), run:
+Requirements to run the checks: PHP 8.4 or newer and Composer 2.8.6 or newer. From the repository root (where the top-level `composer.json` lives), run:
 
 ```bash
 composer install
@@ -67,6 +67,87 @@ composer phpcs-compatibility:85  # Check PHP 8.5 compatibility
 ```
 
 These commands use PHP_CodeSniffer with the PHPCompatibility standard to detect compatibility issues.
+
+#### Marketplace (EQP) checks
+
+The module must permanently pass the blocking checks of the Magento Marketplace Extension Quality Program (EQP). All checks below run locally from the repository root and need PHP 8.4 or newer and Composer 2.8.6 or newer, the same as the compatibility checks above; the code sniffer and copy-paste detector use the same version constraints and parameters as CI (`.github/workflows/marketplace-checks.yml`).
+
+First install the dev dependencies (this only installs the tools, it runs no checks):
+
+```bash
+composer install
+```
+
+This also installs the marketplace tools from `tools/composer.json` into `tools/vendor`.
+
+**Code sniffer** (blocking; Magento2 standard, only severity 10 errors):
+
+```bash
+composer phpcs-magento2
+```
+
+**Copy-paste detector** (advisory — findings must be assessed manually; duplications of Magento core or other extensions are blocking for EQP, the tool also produces false positives):
+
+```bash
+composer phpcpd
+```
+
+It exits with a non-zero status on any finding, including a harmless one — the output is meant for review, not for a blocking gate.
+
+**Package verification** (valid manifest, manifest version equal to the version starting the first line of `CHANGE_LOG.txt`, package zip under 30 MB, no TODO/FIXME markers outside `/Test/`):
+
+```bash
+composer validate Packetery/Checkout/composer.json
+php -r 'echo json_decode(file_get_contents("Packetery/Checkout/composer.json"))->version, PHP_EOL;' && head -1 CHANGE_LOG.txt
+(cd Packetery/Checkout && set -o pipefail && zip -rq - . -x '.git/*' | wc -c)   # bytes, limit 31457280
+grep -rIniE '\b(TODO|FIXME)\b' --include='*.php' --include='*.phtml' --include='*.xml' --include='*.js' Packetery/Checkout | grep -v '/Test/' || echo 'OK: no TODO/FIXME'
+```
+
+**PHP lint**:
+
+```bash
+find Packetery/Checkout -name '*.php' -not -path '*/vendor/*' -print0 | xargs -0 -n1 -P4 php -l >/dev/null
+```
+
+**PHP compatibility** — see the PHP Compatibility Checks section above.
+
+**Malware scan** (the only check CI does not cover; Adobe runs the final scan within EQP, this is a best-effort pre-check). Two tools are used, mirroring Adobe: ClamAV antivirus and YARA with a community ruleset for PHP malware/webshells.
+
+For ClamAV the quickest way is Docker — identical on every OS, no local install, the image ships an up-to-date signature database:
+
+```bash
+docker run --rm -v "$PWD/Packetery/Checkout:/scan:ro" clamav/clamav:stable clamscan -r /scan
+```
+
+On ARM machines (Apple Silicon, ARM Linux) add `--platform linux/amd64` to the command — the image has no ARM build, so without it Docker fails on a missing manifest.
+
+Otherwise install the tools natively:
+
+- macOS: `brew install yara clamav`. ClamAV then needs its config file created, otherwise `freshclam` fails with `Can't open/parse the config file`: `cp "$(brew --prefix)/etc/clamav/freshclam.conf.sample" "$(brew --prefix)/etc/clamav/freshclam.conf"` and comment out the `Example` line in it. Use the Docker command above if you want to skip this setup.
+- Linux: `sudo apt install yara clamav` (Debian/Ubuntu), `sudo dnf install yara clamav clamav-update` (Fedora)
+- Windows: local development typically runs inside WSL2 (Ubuntu) or a Docker container — follow the Linux instructions there. A native setup is possible too: `choco install yara clamav`, or the official binaries (YARA: [github.com/VirusTotal/yara/releases](https://github.com/VirusTotal/yara/releases), ClamAV: [clamav.net/downloads](https://www.clamav.net/downloads))
+
+ClamAV — update the signature database, then scan the module directory:
+
+```bash
+freshclam
+clamscan -r Packetery/Checkout
+```
+
+YARA — with the [php-malware-finder](https://github.com/jvoisin/php-malware-finder) community ruleset:
+
+```bash
+git clone https://github.com/jvoisin/php-malware-finder /tmp/php-malware-finder
+yara -w -r /tmp/php-malware-finder/data/php.yar Packetery/Checkout
+```
+
+Notes:
+
+- All commands in this section expect bash or zsh (the package zip check uses `set -o pipefail`); on Windows run them in WSL2 (or Git Bash — the package zip check additionally needs the `zip` utility, which Git Bash does not bundle; in WSL2 install it via `apt install zip`).
+- Windows clones created before `bin/* text eol=lf` was added keep their CRLF copies — switching branches does not rewrite a file whose content did not change — and `composer phpcs-compatibility:*` then fails with `ERROR: The file "Packetery/Checkout" does not exist`. Refresh the helper once with `rm bin/phpcs-compatibility && git checkout -- bin/phpcs-compatibility`.
+- Debian/Ubuntu packages pull in the `clamav-freshclam` service, which keeps the signature database up to date on its own — running `freshclam` by hand is usually unnecessary there. If `freshclam` complains about a missing configuration (typical for Homebrew and the Windows builds), create `freshclam.conf` from the bundled `freshclam.conf.sample` and comment out the `Example` line.
+- Clone the YARA ruleset outside the repository (as above) — it carries a `samples/` directory with live webshells, which can also trip antivirus or endpoint protection on managed machines. To skip them entirely, fetch only the rules: `git clone --depth 1 --filter=blob:none --sparse https://github.com/jvoisin/php-malware-finder /tmp/php-malware-finder && git -C /tmp/php-malware-finder sparse-checkout set data`, then delete `data/samples`.
+- `composer install` in the repository root also installs the marketplace tools into `tools/`, so it needs network access even when you only want the module dependencies. Behind a proxy or offline it fails on that step with the root `vendor/` already in place; rerun it with network, or use `composer install --no-scripts` and install the tools later with `composer install --working-dir=tools`.
 
 #### Message queue consumer (bulk packet submission)
 
@@ -266,7 +347,7 @@ Cenová pravidla jsou vytvořena jako nedostupná, bez nastavené maximální hm
 
 Modul obsahuje kontroly PHPCompatibility pro zajištění kompatibility s PHP 8.1 až PHP 8.5.
 
-Pro spuštění kontrol je potřeba PHP 8.4 a Composer 2.8.6. V adresáři modulu (kde je `composer.json`) spusťte:
+Pro spuštění kontrol je potřeba PHP 8.4 nebo novější a Composer 2.8.6 nebo novější. V rootu repozitáře (kde je top-level `composer.json`) spusťte:
 
 ```bash
 composer install
@@ -276,6 +357,87 @@ composer phpcs-compatibility:85  # Kontrola kompatibility s PHP 8.5
 ```
 
 Tyto příkazy používají PHP_CodeSniffer se standardem PHPCompatibility pro detekci problémů s kompatibilitou.
+
+#### Marketplace (EQP) kontroly
+
+Modul musí trvale splňovat blokující kontroly programu Magento Marketplace Extension Quality Program (EQP). Všechny kontroly níže se spouštějí lokálně z rootu repozitáře a vyžadují PHP 8.4 nebo novější a Composer 2.8.6 nebo novější, stejně jako kontroly kompatibility výše; code sniffer a copy-paste detector používají stejné version constrainty a parametry jako CI (`.github/workflows/marketplace-checks.yml`).
+
+Nejprve nainstalujte dev závislosti (pouze instaluje nástroje, žádné kontroly nespouští):
+
+```bash
+composer install
+```
+
+Tím se nainstalují i marketplace nástroje z `tools/composer.json` do `tools/vendor`.
+
+**Code sniffer** (blokující; standard Magento2, pouze chyby severity 10):
+
+```bash
+composer phpcs-magento2
+```
+
+**Copy-paste detector** (informativní — nálezy je nutné ručně posoudit; duplicity vůči Magento core nebo jiným rozšířením jsou pro EQP blokující, nástroj má i false positives):
+
+```bash
+composer phpcpd
+```
+
+Skončí nenulovým kódem při jakémkoli nálezu, i neškodném — výstup slouží k posouzení, ne jako blokující brána.
+
+**Package verification** (validní manifest, shoda verze manifestu s verzí na začátku prvního řádku `CHANGE_LOG.txt`, zip balíčku do 30 MB, žádné TODO/FIXME mimo `/Test/`):
+
+```bash
+composer validate Packetery/Checkout/composer.json
+php -r 'echo json_decode(file_get_contents("Packetery/Checkout/composer.json"))->version, PHP_EOL;' && head -1 CHANGE_LOG.txt
+(cd Packetery/Checkout && set -o pipefail && zip -rq - . -x '.git/*' | wc -c)   # bajty, limit 31457280
+grep -rIniE '\b(TODO|FIXME)\b' --include='*.php' --include='*.phtml' --include='*.xml' --include='*.js' Packetery/Checkout | grep -v '/Test/' || echo 'OK: no TODO/FIXME'
+```
+
+**PHP lint**:
+
+```bash
+find Packetery/Checkout -name '*.php' -not -path '*/vendor/*' -print0 | xargs -0 -n1 -P4 php -l >/dev/null
+```
+
+**Kompatibilita PHP** — viz sekce Kontrola kompatibility PHP výše.
+
+**Malware scan** (jediná kontrola, kterou CI nepokrývá; finální scan provádí Adobe v rámci EQP, tohle je best-effort před-kontrola). Používají se dva nástroje po vzoru Adobe: antivirus ClamAV a YARA s komunitní sadou pravidel pro PHP malware/webshelly.
+
+U ClamAV je nejrychlejší cesta Docker — funguje stejně na všech OS, nic se neinstaluje a image má aktuální databázi signatur:
+
+```bash
+docker run --rm -v "$PWD/Packetery/Checkout:/scan:ro" clamav/clamav:stable clamscan -r /scan
+```
+
+Na ARM strojích (Apple Silicon, ARM Linux) přidejte do příkazu `--platform linux/amd64` — image nemá ARM variantu a Docker bez toho skončí chybou o chybějícím manifestu.
+
+Jinak nainstalujte nástroje nativně:
+
+- macOS: `brew install yara clamav`. ClamAV si pak vyžádá vytvoření konfigurace, jinak `freshclam` skončí chybou `Can't open/parse the config file`: `cp "$(brew --prefix)/etc/clamav/freshclam.conf.sample" "$(brew --prefix)/etc/clamav/freshclam.conf"` a v souboru zakomentujte řádek `Example`. Pokud se tomuhle nastavování chcete vyhnout, použijte Docker příkaz výše.
+- Linux: `sudo apt install yara clamav` (Debian/Ubuntu), `sudo dnf install yara clamav clamav-update` (Fedora)
+- Windows: lokální vývoj typicky běží ve WSL2 (Ubuntu) nebo v Docker kontejneru — použijte tam instrukce pro Linux. Nativní cesta je také možná: `choco install yara clamav`, nebo oficiální binárky (YARA: [github.com/VirusTotal/yara/releases](https://github.com/VirusTotal/yara/releases), ClamAV: [clamav.net/downloads](https://www.clamav.net/downloads))
+
+ClamAV — aktualizace databáze signatur a scan adresáře modulu:
+
+```bash
+freshclam
+clamscan -r Packetery/Checkout
+```
+
+YARA — s komunitní sadou pravidel [php-malware-finder](https://github.com/jvoisin/php-malware-finder):
+
+```bash
+git clone https://github.com/jvoisin/php-malware-finder /tmp/php-malware-finder
+yara -w -r /tmp/php-malware-finder/data/php.yar Packetery/Checkout
+```
+
+Poznámky:
+
+- Všechny příkazy v této sekci předpokládají bash nebo zsh (kontrola velikosti zipu používá `set -o pipefail`); na Windows je spouštějte ve WSL2 (nebo v Git Bash — kontrola velikosti zipu navíc potřebuje utilitu `zip`, kterou Git Bash neobsahuje; ve WSL2 ji doinstalujete přes `apt install zip`).
+- Windows klony vytvořené dříve, než přibylo `bin/* text eol=lf`, si CRLF kopie ponechají — přepnutí větve nepřepíše soubor, jehož obsah se nezměnil — a `composer phpcs-compatibility:*` pak padá na `ERROR: The file "Packetery/Checkout" does not exist`. Jednorázově pomůže `rm bin/phpcs-compatibility && git checkout -- bin/phpcs-compatibility`.
+- Balíčky na Debianu/Ubuntu s sebou nesou službu `clamav-freshclam`, která databázi signatur aktualizuje sama — ruční `freshclam` tam obvykle není potřeba. Pokud `freshclam` hlásí chybějící konfiguraci (typicky u Homebrew a Windows buildů), vytvořte `freshclam.conf` z přiloženého `freshclam.conf.sample` a zakomentujte řádek `Example`.
+- Sadu YARA pravidel klonujte mimo repozitář (jak je uvedeno výše) — obsahuje adresář `samples/` s živými webshelly, které navíc mohou na firemním stroji spustit antivirus nebo ochranu koncových stanic. Když je nechcete stahovat vůbec, vezměte jen pravidla: `git clone --depth 1 --filter=blob:none --sparse https://github.com/jvoisin/php-malware-finder /tmp/php-malware-finder && git -C /tmp/php-malware-finder sparse-checkout set data` a potom smažte `data/samples`.
+- `composer install` v rootu repozitáře doinstaluje i marketplace nástroje do `tools/`, takže potřebuje síť i tehdy, když chcete jen závislosti modulu. Za proxy nebo offline spadne až na tomto kroku, root `vendor/` už přitom stojí; pusťte ho znovu se sítí, nebo použijte `composer install --no-scripts` a nástroje doinstalujte později přes `composer install --working-dir=tools`.
 
 #### Message queue consumer (hromadné podání zásilek)
 

--- a/README.md
+++ b/README.md
@@ -108,14 +108,17 @@ composer phpcpd-core -- /tmp/magento-core/app/code/Magento /tmp/magento-core/lib
 
 Only clones crossing the module boundary are reported, so a finding always means shared code. Takes about 20 seconds against the clone and 35 seconds against `vendor/magento`; the script raises `memory_limit` itself, the run peaks around 1.5 GB.
 
-**Package verification** (valid manifest, manifest version equal to the version starting the first line of `CHANGE_LOG.txt`, package zip under 30 MB, no TODO/FIXME markers outside `/Test/`):
+**Package verification** (valid manifest, the manifest rules Adobe lists for extension packages, manifest version equal to the version starting the first line of `CHANGE_LOG.txt`, package zip under 30 MB, no TODO/FIXME markers outside `/Test/`):
 
 ```bash
 composer validate Packetery/Checkout/composer.json
+composer verify-manifest
 php -r 'echo json_decode(file_get_contents("Packetery/Checkout/composer.json"))->version, PHP_EOL;' && head -1 CHANGE_LOG.txt
 (cd Packetery/Checkout && set -o pipefail && zip -rq - . -x '.git/*' | wc -c)   # bytes, limit 31457280
 grep -rIniE '\b(TODO|FIXME)\b' --include='*.php' --include='*.phtml' --include='*.xml' --include='*.js' Packetery/Checkout | grep -v '/Test/' || echo 'OK: no TODO/FIXME'
 ```
+
+`composer verify-manifest` reads the manifest and checks the rules from the Adobe technical review guidelines: declared name, type and version, allowed package type, no `extra.map` or `extra.magento-root-dir`, no dependency on the Magento base packages, no `*` constraint on `magento/*`, no require inline aliases, `registration.php` in `autoload.files` and a namespace in `autoload.psr-4`, plus `registration.php` and a parseable `etc/module.xml`. It also compares the `php` constraint with the version matrix in `.github/workflows/marketplace-checks.yml`, because Adobe rejects a package that narrows the PHP versions its supported Magento versions allow.
 
 **PHP lint**:
 
@@ -413,14 +416,17 @@ composer phpcpd-core -- /tmp/magento-core/app/code/Magento /tmp/magento-core/lib
 
 Hlásí jen klony přes hranici modulu, takže nález vždy znamená přebraný kód. Trvá asi 20 sekund proti clonu a 35 sekund proti `vendor/magento`; `memory_limit` si skript zvedá sám, špička běhu je kolem 1,5 GB.
 
-**Package verification** (validní manifest, shoda verze manifestu s verzí na začátku prvního řádku `CHANGE_LOG.txt`, zip balíčku do 30 MB, žádné TODO/FIXME mimo `/Test/`):
+**Package verification** (validní manifest, pravidla pro manifest rozšíření podle Adobe, shoda verze manifestu s verzí na začátku prvního řádku `CHANGE_LOG.txt`, zip balíčku do 30 MB, žádné TODO/FIXME mimo `/Test/`):
 
 ```bash
 composer validate Packetery/Checkout/composer.json
+composer verify-manifest
 php -r 'echo json_decode(file_get_contents("Packetery/Checkout/composer.json"))->version, PHP_EOL;' && head -1 CHANGE_LOG.txt
 (cd Packetery/Checkout && set -o pipefail && zip -rq - . -x '.git/*' | wc -c)   # bajty, limit 31457280
 grep -rIniE '\b(TODO|FIXME)\b' --include='*.php' --include='*.phtml' --include='*.xml' --include='*.js' Packetery/Checkout | grep -v '/Test/' || echo 'OK: no TODO/FIXME'
 ```
+
+`composer verify-manifest` přečte manifest a ověří pravidla z technical review guidelines Adobe: vyplněné `name`, `type` a `version`, povolený typ balíčku, žádné `extra.map` ani `extra.magento-root-dir`, žádná závislost na base balíčcích Magenta, žádná `*` u `magento/*`, žádné inline aliasy v require, `registration.php` v `autoload.files` a namespace v `autoload.psr-4`, a k tomu existující `registration.php` a parsovatelný `etc/module.xml`. Navíc porovná constraint `php` s maticí verzí v `.github/workflows/marketplace-checks.yml`, protože Adobe odmítá balíček, který zužuje rozsah PHP verzí daný podporovanými verzemi Magenta.
 
 **PHP lint**:
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,20 @@ composer phpcpd
 
 It exits with a non-zero status on any finding, including a harmless one — the output is meant for review, not for a blocking gate.
 
+**Copy-paste detector against Magento core** (advisory for now — the CI job reports a finding without failing the run; this is the duplication EQP rejects, the check above compares the module only with itself):
+
+```bash
+composer phpcpd-core -- /path/to/magento/vendor/magento
+# without an installation at hand, a sparse clone of the PHP sources is enough (~17 s, 112 MB)
+git clone --depth 1 --branch 2.4.9 --filter=blob:none --sparse https://github.com/magento/magento2.git /tmp/magento-core
+git -C /tmp/magento-core sparse-checkout set app/code/Magento lib/internal/Magento
+composer phpcpd-core -- /tmp/magento-core/app/code/Magento /tmp/magento-core/lib/internal/Magento
+```
+
+⚠️ **Performance warning (Windows):** exclude the core checkout from the folders your antivirus scans (usually Windows Defender), otherwise the first run over a fresh checkout can take tens of minutes.
+
+Only clones crossing the module boundary are reported, so a finding always means shared code. Takes about 20 seconds against the clone and 35 seconds against `vendor/magento`; the script raises `memory_limit` itself, the run peaks around 1.5 GB.
+
 **Package verification** (valid manifest, manifest version equal to the version starting the first line of `CHANGE_LOG.txt`, package zip under 30 MB, no TODO/FIXME markers outside `/Test/`):
 
 ```bash
@@ -144,6 +158,7 @@ yara -w -r /tmp/php-malware-finder/data/php.yar Packetery/Checkout
 Notes:
 
 - All commands in this section expect bash or zsh (the package zip check uses `set -o pipefail`); on Windows run them in WSL2 (or Git Bash — the package zip check additionally needs the `zip` utility, which Git Bash does not bundle; in WSL2 install it via `apt install zip`).
+- The copy-paste detector against Magento core needs WSL2 on Windows, Git Bash is not enough: a native Windows PHP cannot open the `/c/…` paths Git Bash produces, and the shell rewrites a Windows path back to that form. The script asks the scanning PHP whether it sees the files, so this ends as a loud failure, not as a clean run.
 - Windows clones created before `bin/* text eol=lf` was added keep their CRLF copies — switching branches does not rewrite a file whose content did not change — and `composer phpcs-compatibility:*` then fails with `ERROR: The file "Packetery/Checkout" does not exist`. Refresh the helper once with `rm bin/phpcs-compatibility && git checkout -- bin/phpcs-compatibility`.
 - Debian/Ubuntu packages pull in the `clamav-freshclam` service, which keeps the signature database up to date on its own — running `freshclam` by hand is usually unnecessary there. If `freshclam` complains about a missing configuration (typical for Homebrew and the Windows builds), create `freshclam.conf` from the bundled `freshclam.conf.sample` and comment out the `Example` line.
 - Clone the YARA ruleset outside the repository (as above) — it carries a `samples/` directory with live webshells, which can also trip antivirus or endpoint protection on managed machines. To skip them entirely, fetch only the rules: `git clone --depth 1 --filter=blob:none --sparse https://github.com/jvoisin/php-malware-finder /tmp/php-malware-finder && git -C /tmp/php-malware-finder sparse-checkout set data`, then delete `data/samples`.
@@ -384,6 +399,20 @@ composer phpcpd
 
 Skončí nenulovým kódem při jakémkoli nálezu, i neškodném — výstup slouží k posouzení, ne jako blokující brána.
 
+**Copy-paste detector proti Magento core** (zatím informativní — CI job nález vypíše, ale run neshodí; tohle je duplicita, kterou EQP odmítá, kontrola výše porovnává modul jen sám se sebou):
+
+```bash
+composer phpcpd-core -- /cesta/k/magentu/vendor/magento
+# když instalace po ruce není, stačí sparse clone se zdrojáky (~17 s, 112 MB)
+git clone --depth 1 --branch 2.4.9 --filter=blob:none --sparse https://github.com/magento/magento2.git /tmp/magento-core
+git -C /tmp/magento-core sparse-checkout set app/code/Magento lib/internal/Magento
+composer phpcpd-core -- /tmp/magento-core/app/code/Magento /tmp/magento-core/lib/internal/Magento
+```
+
+⚠️ **Upozornění na výkon (Windows):** složku se staženým jádrem vylučte z testovaných složek v antiviru (zpravidla Windows Defenderu), jinak první běh nad čerstvým checkoutem může zabrat i desítky minut.
+
+Hlásí jen klony přes hranici modulu, takže nález vždy znamená přebraný kód. Trvá asi 20 sekund proti clonu a 35 sekund proti `vendor/magento`; `memory_limit` si skript zvedá sám, špička běhu je kolem 1,5 GB.
+
 **Package verification** (validní manifest, shoda verze manifestu s verzí na začátku prvního řádku `CHANGE_LOG.txt`, zip balíčku do 30 MB, žádné TODO/FIXME mimo `/Test/`):
 
 ```bash
@@ -434,6 +463,7 @@ yara -w -r /tmp/php-malware-finder/data/php.yar Packetery/Checkout
 Poznámky:
 
 - Všechny příkazy v této sekci předpokládají bash nebo zsh (kontrola velikosti zipu používá `set -o pipefail`); na Windows je spouštějte ve WSL2 (nebo v Git Bash — kontrola velikosti zipu navíc potřebuje utilitu `zip`, kterou Git Bash neobsahuje; ve WSL2 ji doinstalujete přes `apt install zip`).
+- Copy-paste detector proti Magento core potřebuje na Windows WSL2, Git Bash nestačí: nativní Windows PHP neumí otevřít cesty ve tvaru `/c/…`, které Git Bash vytváří, a shell si windowsový tvar cesty přepíše zpátky na něj. Skript se skenujícího PHP zeptá, jestli soubory vidí, takže to skončí hlasitou chybou, ne čistým během.
 - Windows klony vytvořené dříve, než přibylo `bin/* text eol=lf`, si CRLF kopie ponechají — přepnutí větve nepřepíše soubor, jehož obsah se nezměnil — a `composer phpcs-compatibility:*` pak padá na `ERROR: The file "Packetery/Checkout" does not exist`. Jednorázově pomůže `rm bin/phpcs-compatibility && git checkout -- bin/phpcs-compatibility`.
 - Balíčky na Debianu/Ubuntu s sebou nesou službu `clamav-freshclam`, která databázi signatur aktualizuje sama — ruční `freshclam` tam obvykle není potřeba. Pokud `freshclam` hlásí chybějící konfiguraci (typicky u Homebrew a Windows buildů), vytvořte `freshclam.conf` z přiloženého `freshclam.conf.sample` a zakomentujte řádek `Example`.
 - Sadu YARA pravidel klonujte mimo repozitář (jak je uvedeno výše) — obsahuje adresář `samples/` s živými webshelly, které navíc mohou na firemním stroji spustit antivirus nebo ochranu koncových stanic. Když je nechcete stahovat vůbec, vezměte jen pravidla: `git clone --depth 1 --filter=blob:none --sparse https://github.com/jvoisin/php-malware-finder /tmp/php-malware-finder && git -C /tmp/php-malware-finder sparse-checkout set data` a potom smažte `data/samples`.

--- a/bin/phpcpd-core
+++ b/bin/phpcpd-core
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Copy-paste detector between the module and Magento core, the category the Marketplace blocks.
+# Usage: bin/phpcpd-core <path-to-core> [more-paths…]   (or set MAGENTO_CORE_PATH)
+#
+# Clones inside core and clones inside the module are ignored, only pairs crossing the boundary fail.
+set -euo pipefail
+
+MODULE="Packetery/Checkout"
+MARKER="/${MODULE}/"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PHPCPD="${ROOT}/tools/vendor/bin/phpcpd"
+
+CORE_PATHS=("$@")
+# MAGENTO_CORE_PATH carries one path and stays quoted, so a directory with a space still works,
+# several paths go in as arguments
+if [ ${#CORE_PATHS[@]} -eq 0 ] && [ -n "${MAGENTO_CORE_PATH:-}" ]; then
+    CORE_PATHS=("$MAGENTO_CORE_PATH")
+fi
+
+if [ ${#CORE_PATHS[@]} -eq 0 ]; then
+    echo "usage: bin/phpcpd-core <path-to-magento-core> [more-paths…]" >&2
+    echo "       point it at vendor/magento of a Magento install, or at app/code/Magento" >&2
+    echo "       and lib/internal/Magento of a magento/magento2 checkout" >&2
+    exit 2
+fi
+
+if [ ! -x "$PHPCPD" ]; then
+    echo "FAIL: $PHPCPD is missing, run composer install first" >&2
+    exit 2
+fi
+
+# Core paths are resolved while still in the caller's directory, phpcpd reads paths from the CWD
+for i in "${!CORE_PATHS[@]}"; do
+    path="${CORE_PATHS[$i]}"
+    if [ ! -d "$path" ]; then
+        echo "FAIL: not a directory: $path" >&2
+        exit 2
+    fi
+    CORE_PATHS[$i]="$(cd "$path" && pwd)"
+done
+
+# Run from the repository root, from anywhere else phpcpd would not find the module at all
+cd "$ROOT"
+
+if [ ! -d "$MODULE" ]; then
+    echo "FAIL: $MODULE not found in $ROOT" >&2
+    exit 2
+fi
+
+# The checks above run in the shell, the scan runs in PHP, and the two can disagree: Git Bash resolves
+# /c/… paths that a native Windows PHP cannot open. phpcpd then reads nothing from the core, keeps
+# going and prints a clean report, which reads as a pass. Only the scanning interpreter can confirm
+# that it sees the files, so it is asked before the scan, for the module and for every core path.
+if ! php -r '
+    foreach (array_slice($argv, 1) as $path) {
+        if (!is_dir($path)) {
+            fwrite(STDERR, "FAIL: PHP cannot open the directory: {$path}\n");
+            exit(2);
+        }
+
+        $files = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator(
+                $path,
+                FilesystemIterator::SKIP_DOTS | FilesystemIterator::FOLLOW_SYMLINKS
+            ),
+            RecursiveIteratorIterator::LEAVES_ONLY,
+            RecursiveIteratorIterator::CATCH_GET_CHILD
+        );
+
+        $found = false;
+        foreach ($files as $file) {
+            if ($file->getExtension() === "php") {
+                $found = true;
+                break;
+            }
+        }
+
+        if (!$found) {
+            fwrite(STDERR, "FAIL: PHP sees no PHP files under: {$path}\n");
+            exit(2);
+        }
+    }
+' "$MODULE" "${CORE_PATHS[@]}"; then
+    echo "      an incomplete core checkout, or a path the shell resolves and PHP does not" >&2
+    echo "      a native Windows PHP does not see the /c/… paths of Git Bash, run this check in WSL2" >&2
+    exit 2
+fi
+
+REPORT="$(mktemp)"
+trap 'rm -f "$REPORT"' EXIT
+
+# memory_limit=-1: the run peaks around 1.5 GB on the full core and the 128 MB default dies on it.
+set +e
+php -d memory_limit=-1 "$PHPCPD" --exclude "${MODULE}/Test" "$MODULE" "${CORE_PATHS[@]}" > "$REPORT"
+STATUS=$?
+set -e
+
+# phpcpd returns 1 both for clones found and for a run that scanned nothing,
+# so the verdict line decides whether the report can be trusted
+if [ "$STATUS" -gt 1 ] || ! grep -qE 'No code clones found|Found [0-9]+ code clones' "$REPORT"; then
+    echo "FAIL: phpcpd did not finish, exit ${STATUS}" >&2
+    cat "$REPORT" >&2
+    exit 2
+fi
+
+awk -v marker="$MARKER" '
+    BEGIN { RS = ""; found = 0 }
+    /^[[:space:]]*-/ {
+        lines = split($0, group, "\n")
+        module_side = 0
+        other_side = 0
+        for (i = 1; i <= lines; i++) {
+            if (group[i] !~ /:[0-9]+/) {
+                continue
+            }
+            # Windows realpath() returns backslashes, the marker is written with forward slashes,
+            # so the comparison runs on a normalized copy and the report keeps the real paths
+            normalized = group[i]
+            gsub(/\\/, "/", normalized)
+            if (index(normalized, marker)) {
+                module_side = 1
+            } else {
+                other_side = 1
+            }
+        }
+        if (module_side && other_side) {
+            found++
+            print $0 "\n"
+        }
+    }
+    END {
+        if (found) {
+            print "FAIL: " found " clone(s) shared between the module and core"
+            exit 1
+        }
+        print "OK: no code shared between the module and core"
+    }
+' "$REPORT"

--- a/bin/verify-manifest
+++ b/bin/verify-manifest
@@ -1,0 +1,177 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Package verification rules the Marketplace applies to the module manifest.
+ * Usage: bin/verify-manifest [path-to-module]   (default: Packetery/Checkout)
+ *
+ * The rules come from the Adobe technical review guidelines, section
+ * "Extension package verification". Zip size and the TODO/FIXME markers are
+ * separate steps, they read the whole package, not the manifest.
+ */
+
+declare(strict_types=1);
+
+const ALLOWED_TYPES = ['magento2-module', 'magento2-language', 'metapackage'];
+
+const FORBIDDEN_REQUIRES = [
+    'magento/magento-composer-installer',
+    'magento/magento2-base',
+    'magento/product-community-edition',
+    'magento/magento2-ee-base',
+    'magento/product-enterprise-edition',
+];
+
+$repositoryRoot = dirname(__DIR__);
+// The default is anchored to the script, the same way the workflow path below is, so the check does
+// not depend on the caller's directory
+$module = rtrim($argv[1] ?? "{$repositoryRoot}/Packetery/Checkout", '/');
+$manifestPath = "{$module}/composer.json";
+
+if (!is_file($manifestPath)) {
+    fwrite(STDERR, "FAIL: {$manifestPath} not found\n");
+    exit(2);
+}
+
+$manifest = json_decode((string) file_get_contents($manifestPath), true);
+if (!is_array($manifest) || array_is_list($manifest)) {
+    fwrite(STDERR, "FAIL: {$manifestPath} is not valid JSON\n");
+    exit(2);
+}
+
+$failures = [];
+
+function check(string $rule, bool $passed, string $detail = ''): void
+{
+    global $failures;
+
+    $status = $passed ? 'OK  ' : 'FAIL';
+    echo "{$status} {$rule}" . ($detail !== '' ? ": {$detail}" : '') . "\n";
+
+    if (!$passed) {
+        $failures[] = $rule;
+    }
+}
+
+foreach (['name', 'type', 'version'] as $key) {
+    $value = $manifest[$key] ?? '';
+    check("manifest declares {$key}", is_string($value) && $value !== '', is_string($value) ? $value : '');
+}
+
+$type = $manifest['type'] ?? '';
+check(
+    'package type is one of ' . implode(', ', ALLOWED_TYPES),
+    in_array($type, ALLOWED_TYPES, true),
+    is_string($type) ? $type : ''
+);
+
+$extra = is_array($manifest['extra'] ?? null) ? $manifest['extra'] : [];
+foreach (['map', 'magento-root-dir'] as $key) {
+    check("manifest does not declare extra.{$key}", !array_key_exists($key, $extra));
+}
+
+$require = is_array($manifest['require'] ?? null) ? $manifest['require'] : [];
+
+$forbidden = array_intersect(FORBIDDEN_REQUIRES, array_keys($require));
+check('no dependency on the Magento base packages', $forbidden === [], implode(', ', $forbidden));
+
+$wildcards = [];
+$aliases = [];
+foreach ($require as $package => $constraint) {
+    if (str_starts_with((string) $package, 'magento/') && str_contains((string) $constraint, '*')) {
+        $wildcards[] = "{$package}: {$constraint}";
+    }
+    if (str_contains((string) $constraint, ' as ')) {
+        $aliases[] = "{$package}: {$constraint}";
+    }
+}
+check('no "*" version constraint on magento/* packages', $wildcards === [], implode(', ', $wildcards));
+check('no require inline aliases', $aliases === [], implode(', ', $aliases));
+
+$autoloadFiles = $manifest['autoload']['files'] ?? [];
+$autoloadFiles = is_array($autoloadFiles) ? $autoloadFiles : [];
+$registrationListed = false;
+foreach ($autoloadFiles as $file) {
+    if (str_ends_with((string) $file, 'registration.php')) {
+        $registrationListed = true;
+    }
+}
+check('autoload.files includes registration.php', $registrationListed, implode(', ', $autoloadFiles));
+
+$psr4 = $manifest['autoload']['psr-4'] ?? [];
+$namespaces = is_array($psr4) ? array_keys($psr4) : [];
+check('autoload.psr-4 declares a namespace', $namespaces !== [], implode(', ', $namespaces));
+
+// Adobe forbids narrowing the PHP versions the supported Magento versions allow. The CI matrix is
+// the list we claim to support, so the manifest must accept exactly those versions, no more, no less.
+// Resolved from the script location, the check must not depend on the caller's directory
+// Reading only the first matrix would compare the wrong list once the workflow grows a second one,
+// so every php-version matrix is collected and they all have to agree
+$workflow = "{$repositoryRoot}/.github/workflows/marketplace-checks.yml";
+$matrix = [];
+$matricesDisagree = false;
+if (
+    is_file($workflow)
+    && preg_match_all("/php-version:\s*\[([^\]]+)\]/", (string) file_get_contents($workflow), $found)
+) {
+    $matrices = [];
+    foreach ($found[1] as $list) {
+        preg_match_all("/\d+\.\d+/", $list, $versions);
+        $candidate = $versions[0];
+        sort($candidate);
+        $matrices[implode(', ', $candidate)] = $candidate;
+    }
+
+    if (count($matrices) === 1) {
+        $matrix = reset($matrices);
+    } else {
+        $matricesDisagree = true;
+    }
+}
+
+$constraint = (string) ($require['php'] ?? '');
+$declared = [];
+$parsable = $constraint !== '' && preg_match('/^\s*~\d+\.\d+\.0(\s*\|\|\s*~\d+\.\d+\.0)*\s*$/', $constraint) === 1;
+if ($parsable) {
+    preg_match_all('/~(\d+\.\d+)\.0/', $constraint, $found);
+    $declared = $found[1];
+}
+
+if ($matrix === [] || !$parsable) {
+    if (!$parsable) {
+        $detail = "cannot read constraint \"{$constraint}\", check it by hand";
+    } elseif ($matricesDisagree) {
+        $detail = "php-version matrices in {$workflow} do not agree, check them by hand";
+    } else {
+        $detail = "no php-version matrix in {$workflow}";
+    }
+
+    check('php constraint matches the tested versions', false, $detail);
+} else {
+    sort($matrix);
+    sort($declared);
+    check(
+        'php constraint matches the tested versions',
+        $matrix === $declared,
+        'manifest ' . implode(', ', $declared) . ' vs CI ' . implode(', ', $matrix)
+    );
+}
+
+check('registration.php exists', is_file("{$module}/registration.php"));
+
+$moduleXmlPath = "{$module}/etc/module.xml";
+$moduleXmlValid = false;
+if (is_file($moduleXmlPath)) {
+    $previous = libxml_use_internal_errors(true);
+    $moduleXmlValid = simplexml_load_file($moduleXmlPath) !== false;
+    libxml_clear_errors();
+    libxml_use_internal_errors($previous);
+}
+check('etc/module.xml exists and parses', $moduleXmlValid);
+
+if ($failures !== []) {
+    echo "\nFAIL: " . count($failures) . " manifest rule(s) violated\n";
+    exit(1);
+}
+
+echo "\nOK: manifest meets the Marketplace package verification rules\n";

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "phpcs-compatibility:84": "bash bin/phpcs-compatibility 8.4",
         "phpcs-compatibility:85": "bash bin/phpcs-compatibility 8.5",
         "phpcs-magento2": "@php tools/vendor/bin/phpcs --standard=Magento2 --error-severity=10 --warning-severity=0 --extensions=php,phtml --ignore-annotations Packetery/Checkout",
-        "phpcpd": "@php tools/vendor/bin/phpcpd --exclude Packetery/Checkout/Test Packetery/Checkout"
+        "phpcpd": "@php tools/vendor/bin/phpcpd --exclude Packetery/Checkout/Test Packetery/Checkout",
+        "phpcpd-core": "bash bin/phpcpd-core"
     },
     "config": {
         "allow-plugins": {
@@ -28,4 +29,3 @@
         }
     }
 }
-

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "phpcs-compatibility:85": "bash bin/phpcs-compatibility 8.5",
         "phpcs-magento2": "@php tools/vendor/bin/phpcs --standard=Magento2 --error-severity=10 --warning-severity=0 --extensions=php,phtml --ignore-annotations Packetery/Checkout",
         "phpcpd": "@php tools/vendor/bin/phpcpd --exclude Packetery/Checkout/Test Packetery/Checkout",
-        "phpcpd-core": "bash bin/phpcpd-core"
+        "phpcpd-core": "bash bin/phpcpd-core",
+        "verify-manifest": "@php bin/verify-manifest"
     },
     "config": {
         "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,14 @@
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0"
     },
     "scripts": {
+        "post-install-cmd": "@marketplace-tools-install",
+        "post-update-cmd": "@marketplace-tools-install",
+        "marketplace-tools-install": "@composer install --working-dir=tools --no-interaction",
         "phpcs-compatibility:81": "bash bin/phpcs-compatibility 8.1",
         "phpcs-compatibility:84": "bash bin/phpcs-compatibility 8.4",
-        "phpcs-compatibility:85": "bash bin/phpcs-compatibility 8.5"
+        "phpcs-compatibility:85": "bash bin/phpcs-compatibility 8.5",
+        "phpcs-magento2": "@php tools/vendor/bin/phpcs --standard=Magento2 --error-severity=10 --warning-severity=0 --extensions=php,phtml --ignore-annotations Packetery/Checkout",
+        "phpcpd": "@php tools/vendor/bin/phpcpd --exclude Packetery/Checkout/Test Packetery/Checkout"
     },
     "config": {
         "allow-plugins": {

--- a/tools/composer.json
+++ b/tools/composer.json
@@ -1,0 +1,15 @@
+{
+    "name": "packetery/marketplace-tools",
+    "description": "Marketplace (EQP) check tools, kept out of the root dependency tree: the Magento coding standard requires PHP_CodeSniffer 3.x, while the root PHPCompatibility ruleset needs 4.x.",
+    "type": "project",
+    "require": {
+        "magento/magento-coding-standard": "^40",
+        "systemsdk/phpcpd": "^9.0"
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
+    },
+    "license": "proprietary"
+}

--- a/tools/composer.lock
+++ b/tools/composer.lock
@@ -1,0 +1,976 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "94fab81c84a24a1900cb43d463af7241",
+    "packages": [
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/composer-installer.git",
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.2",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.1.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.2",
+                "ext-json": "*",
+                "ext-zip": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcompatibility/php-compatibility": "^9.0 || ^10.0.0@dev",
+                "yoast/phpunit-polyfills": "^1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "opensource@frenck.dev",
+                    "homepage": "https://frenck.dev",
+                    "role": "Open source developer"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/composer-installer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcbf",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/composer-installer/issues",
+                "security": "https://github.com/PHPCSStandards/composer-installer/security/policy",
+                "source": "https://github.com/PHPCSStandards/composer-installer"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2026-05-06T08:26:05+00:00"
+        },
+        {
+            "name": "magento/magento-coding-standard",
+            "version": "40",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/magento/magento-coding-standard.git",
+                "reference": "808617f36009f0c9d6ca867c3d7322fdd0924186"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/magento/magento-coding-standard/zipball/808617f36009f0c9d6ca867c3d7322fdd0924186",
+                "reference": "808617f36009f0c9d6ca867c3d7322fdd0924186",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-simplexml": "*",
+                "magento/php-compatibility-fork": "^0.1",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+                "phpcsstandards/phpcsutils": "^1.2.2",
+                "rector/rector": "^1.2.4 || ^2.0.0",
+                "squizlabs/php_codesniffer": "^3.10.2",
+                "webonyx/graphql-php": "^15.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6.20",
+                "yoast/phpunit-polyfills": "^1.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "Magento2\\": "Magento2/",
+                    "Magento2Framework\\": "Magento2Framework/"
+                },
+                "classmap": [
+                    "PHP_CodeSniffer/Tokenizers/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "A set of Magento specific PHP CodeSniffer rules.",
+            "support": {
+                "issues": "https://github.com/magento/magento-coding-standard/issues",
+                "source": "https://github.com/magento/magento-coding-standard/tree/v40"
+            },
+            "time": "2026-03-06T05:38:38+00:00"
+        },
+        {
+            "name": "magento/php-compatibility-fork",
+            "version": "v0.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/magento/PHPCompatibilityFork.git",
+                "reference": "1cf031c2a68e3e52e460c5690ed8d1d6d45f4653"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/magento/PHPCompatibilityFork/zipball/1cf031c2a68e3e52e460c5690ed8d1d6d45f4653",
+                "reference": "1cf031c2a68e3e52e460c5690ed8d1d6d45f4653",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpcsstandards/phpcsutils": "^1.0.5",
+                "squizlabs/php_codesniffer": "^3.7.1"
+            },
+            "replace": {
+                "phpcompatibility/php-compatibility": "*",
+                "wimg/php-compatibility": "*"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcsstandards/phpcsdevcs": "^1.1.3",
+                "phpcsstandards/phpcsdevtools": "^1.2.0",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4 || ^10.1.0",
+                "yoast/phpunit-polyfills": "^1.0.5 || ^2.0.0"
+            },
+            "suggest": {
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "homepage": "https://github.com/wimg",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
+                }
+            ],
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility. This is a fork of phpcompatibility/php-compatibility",
+            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibility/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibility"
+            },
+            "time": "2023-11-29T22:34:17+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsutils",
+            "version": "1.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
+                "reference": "5f35d9408c54d7b529501f3c688b6eae562aea1f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/5f35d9408c54d7b529501f3c688b6eae562aea1f",
+                "reference": "5f35d9408c54d7b529501f3c688b6eae562aea1f",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.13.5 || ^4.0.1"
+            },
+            "require-dev": {
+                "ext-filter": "*",
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcsstandards/phpcsdevcs": "^1.2.0",
+                "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0 || ^3.0.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "PHPCSUtils/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSUtils/graphs/contributors"
+                }
+            ],
+            "description": "A suite of utility functions for use with PHP_CodeSniffer",
+            "homepage": "https://phpcsutils.com/",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "phpcs3",
+                "phpcs4",
+                "standards",
+                "static analysis",
+                "tokens",
+                "utility"
+            ],
+            "support": {
+                "docs": "https://phpcsutils.com/",
+                "issues": "https://github.com/PHPCSStandards/PHPCSUtils/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSUtils/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHPCSUtils"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2026-07-27T10:28:41+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "2.2.8",
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e285254e60f33c21902efef4a926ca0987c06804",
+                "reference": "e285254e60f33c21902efef4a926ca0987c06804",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ondřej Mirtes"
+                },
+                {
+                    "name": "Markus Staab"
+                },
+                {
+                    "name": "Vincent Langlet"
+                }
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-08-04T22:21:45+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "7.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "3ccaa29123548190af12fee7af078dcd7f3ddfab"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3ccaa29123548190af12fee7af078dcd7f3ddfab",
+                "reference": "3ccaa29123548190af12fee7af078dcd7f3ddfab",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^13.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/7.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-file-iterator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-08-10T06:43:12+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "9.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "a0e12065831f6ab0d83120dc61513eb8d9a966f6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/a0e12065831f6ab0d83120dc61513eb8d9a966f6",
+                "reference": "a0e12065831f6ab0d83120dc61513eb8d9a966f6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^13.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "9.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "security": "https://github.com/sebastianbergmann/php-timer/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/9.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-timer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-06T04:37:53+00:00"
+        },
+        {
+            "name": "rector/rector",
+            "version": "2.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rectorphp/rector.git",
+                "reference": "b8e68f058bca43e01a2e1caa51ef022d6551ed95"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/b8e68f058bca43e01a2e1caa51ef022d6551ed95",
+                "reference": "b8e68f058bca43e01a2e1caa51ef022d6551ed95",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0",
+                "phpstan/phpstan": "^2.2.6"
+            },
+            "conflict": {
+                "rector/rector-doctrine": "*",
+                "rector/rector-downgrade-php": "*",
+                "rector/rector-phpunit": "*",
+                "rector/rector-symfony": "*"
+            },
+            "suggest": {
+                "ext-dom": "To manipulate phpunit.xml via the custom-rule command"
+            },
+            "bin": [
+                "bin/rector"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Instant Upgrade and Automated Refactoring of any PHP code",
+            "homepage": "https://getrector.com/",
+            "keywords": [
+                "automation",
+                "dev",
+                "migration",
+                "refactoring"
+            ],
+            "support": {
+                "issues": "https://github.com/rectorphp/rector/issues",
+                "source": "https://github.com/rectorphp/rector/tree/2.6.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/tomasvotruba",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-08-03T17:30:34+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "5.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "eeb759ad3146b7096fb59c3195d39e071cd409e3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/eeb759ad3146b7096fb59c3195d39e071cd409e3",
+                "reference": "eeb759ad3146b7096fb59c3195d39e071cd409e3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^13.2.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/5.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/cli-parser",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-08-01T04:27:14+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "7.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "ad37a5552c8e2b88572249fdc19b6da7792e021b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/ad37a5552c8e2b88572249fdc19b6da7792e021b",
+                "reference": "ad37a5552c8e2b88572249fdc19b6da7792e021b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "security": "https://github.com/sebastianbergmann/version/security/policy",
+                "source": "https://github.com/sebastianbergmann/version/tree/7.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/version",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-06T04:52:52+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.13.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
+            },
+            "bin": [
+                "bin/phpcbf",
+                "bin/phpcs"
+            ],
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "Former lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "Current lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHP_CodeSniffer/issues",
+                "security": "https://github.com/PHPCSStandards/PHP_CodeSniffer/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+                "wiki": "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2026-08-06T00:17:32+00:00"
+        },
+        {
+            "name": "systemsdk/phpcpd",
+            "version": "v9.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/systemsdk/phpcpd.git",
+                "reference": "7c8fcc2dd5b34c1c2baeef7ccdda8126c4fd8a85"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/systemsdk/phpcpd/zipball/7c8fcc2dd5b34c1c2baeef7ccdda8126c4fd8a85",
+                "reference": "7c8fcc2dd5b34c1c2baeef7ccdda8126c4fd8a85",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.4",
+                "phpunit/php-file-iterator": "^7.0",
+                "phpunit/php-timer": "^9.0",
+                "sebastian/cli-parser": "^5.0",
+                "sebastian/version": "^7.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.9",
+                "roave/security-advisories": "dev-latest"
+            },
+            "bin": [
+                "phpcpd"
+            ],
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": true,
+                    "target-directory": "tools"
+                },
+                "projectTitle": "phpcpd",
+                "allow-contrib": "true"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Systemsdk\\PhpCPD\\": "src/"
+                },
+                "classmap": [
+                    "src/"
+                ],
+                "exclude-from-classmap": []
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                },
+                {
+                    "name": "Dmitry Kravtsov",
+                    "email": "dmytro.kravtsov@systemsdk.com",
+                    "homepage": "https://github.com/systemsdk",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Copy/Paste Detector for PHP code",
+            "homepage": "https://github.com/systemsdk/phpcpd",
+            "keywords": [
+                "Copy paste detector",
+                "Php code quality tool",
+                "php",
+                "phpcpd"
+            ],
+            "support": {
+                "issues": "https://github.com/systemsdk/phpcpd/issues",
+                "source": "https://github.com/systemsdk/phpcpd/tree/v9.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://secure.wayforpay.com/button/b0b1af16db515",
+                    "type": "other"
+                }
+            ],
+            "time": "2026-03-08T16:27:15+00:00"
+        },
+        {
+            "name": "webonyx/graphql-php",
+            "version": "v15.37.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webonyx/graphql-php.git",
+                "reference": "8c620457202b5c8d81582338238f769790ef718a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/8c620457202b5c8d81582338238f769790ef718a",
+                "reference": "8c620457202b5c8d81582338238f769790ef718a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "php": "^7.4 || ^8"
+            },
+            "require-dev": {
+                "amphp/amp": "^2.6 || ^3",
+                "amphp/http-server": "^2.1 || ^3",
+                "dms/phpunit-arraysubset-asserts": "dev-master",
+                "ergebnis/composer-normalize": "^2.28",
+                "friendsofphp/php-cs-fixer": "3.95.17",
+                "mll-lab/php-cs-fixer-config": "5.13.0",
+                "nyholm/psr7": "^1.5",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "2.2.6",
+                "phpstan/phpstan-phpunit": "2.0.18",
+                "phpstan/phpstan-strict-rules": "2.0.12",
+                "phpunit/phpunit": "^9.5 || ^10.5.21 || ^11",
+                "psr/http-message": "^1 || ^2",
+                "react/http": "^1.6",
+                "react/promise": "^2.0 || ^3.0",
+                "rector/rector": "^2.0",
+                "symfony/polyfill-php81": "^1.23",
+                "symfony/var-exporter": "^5 || ^6 || ^7 || ^8",
+                "thecodingmachine/safe": "^1.3 || ^2 || ^3",
+                "ticketswap/phpstan-error-formatter": "1.3.0"
+            },
+            "suggest": {
+                "amphp/amp": "To leverage async resolving on AMPHP platform (v3 with AmpFutureAdapter, v2 with AmpPromiseAdapter)",
+                "amphp/http-server": "To leverage async resolving with webserver on AMPHP platform",
+                "psr/http-message": "To use standard GraphQL server",
+                "react/promise": "To leverage async resolving on React PHP platform"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "GraphQL\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A PHP port of GraphQL reference implementation",
+            "homepage": "https://github.com/webonyx/graphql-php",
+            "keywords": [
+                "api",
+                "graphql"
+            ],
+            "support": {
+                "issues": "https://github.com/webonyx/graphql-php/issues",
+                "source": "https://github.com/webonyx/graphql-php/tree/v15.37.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/spawnia",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/webonyx-graphql-php",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2026-07-29T07:35:47+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
+}


### PR DESCRIPTION
https://packeta.atlassian.net/browse/PES-3294

- Lokální spouštění blokujících marketplace (EQP) kontrol a dokumentace k nim.
- Uvnitř `Packetery/` se nemění nic, odevzdávaný balíček zůstává stejný.
- **Nástroje v `tools/` jako oddělený Composer projekt** — v jednom stromu se nesejdou: coding standard 40 chce phpcs 3.x, root drží 4.x kvůli PHPCompatibility 10. Ve sloučené variantě by kontrola PHP 8.4 a 8.5 přestala hlídat cokoliv (0 pravidel proti 622 a 137). `composer install` v rootu si nástroje doinstaluje sám, lock je commitnutý kvůli determinismu.
- **Nová kontrola duplicit modul × Magento jádro** (`bin/phpcpd-core`, composer script, CI job `copy-paste-vs-core` s cachovaným jádrem). Kontrola ze zadání porovnává modul jen sám se sebou, takže kategorii, kvůli které Marketplace balíček odmítá — kód převzatý z Commerce nebo z jiného rozšíření — vůbec nevidí. Hlásí jen klony přes hranici modulu, takže nález vždy znamená přebraný kód.
- **Nová kontrola manifestu** (`bin/verify-manifest`, composer script, krok v jobu `package-verification`). Package verification ze zadání kryla čtyři požadavky Adobe, jejich seznam pro rozšíření jich má víc; skript hlídá 14 pravidel včetně toho, že manifest nezužuje rozsah PHP daný podporovanými verzemi Magenta.
- **Opravy v CI** — vyloučení `Test` u phpcpd se dosud nechytalo (`--exclude` je prefix cesty vůči pracovnímu adresáři, takže se testy skenovaly), job `php-compatibility` běží s `--no-scripts`.

- **README v obou mutacích** — příkazy všech kontrol včetně instalace YARA a ClamAV pro macOS, Linux a Windows.
- **Bez changelog entry** — uživatel z toho nic neuvidí, je to vývojářský tooling, CI a README, a entry by musela viset pod už vydanou 2.5.0.

